### PR TITLE
feat(#11): 틀린 문제 풀어보기 페이지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "tailwindcss": "^4.1.16",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.45.0",
-        "vite": "^7.1.7"
+        "vite": "^7.2.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4805,9 +4805,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
-      "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
+      "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "tailwindcss": "^4.1.16",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.45.0",
-    "vite": "^7.1.7"
+    "vite": "^7.2.2"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
 import { router } from '@/app/router';
 
-type AppProps = Record<string, never>;
-
-const App = ({}: AppProps) => {
+const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -238,12 +238,15 @@ const HomePage = () => {
               </span>
             </a>
 
-            <button className="bg-white px-l py-4 rounded-[12px] shadow-sm hover:shadow-md transition-shadow flex items-center gap-1">
+            <a
+              href="/wrong-quizzes"
+              className="bg-white px-l py-4 rounded-[12px] shadow-sm hover:shadow-md transition-shadow flex items-center gap-1"
+            >
               <Icon name="write" size={28} />
               <span className="text-body1-medium text-gray-900">
                 틀린문제 풀어보기
               </span>
-            </button>
+            </a>
           </div>
         </div>
       </main>
@@ -296,12 +299,15 @@ const HomePage = () => {
             </span>
           </a>
 
-          <button className="bg-white px-3 py-[10px] rounded-[8px] shadow-sm flex items-center gap-1">
+          <a
+            href="/wrong-quizzes"
+            className="bg-white px-3 py-[10px] rounded-[8px] shadow-sm flex items-center gap-1"
+          >
             <Icon name="write" size={24} />
             <span className="text-tint-regular text-gray-900">
               틀린문제 풀어보기
             </span>
-          </button>
+          </a>
         </div>
       </main>
 

--- a/src/app/pages/WrongQuizPage.tsx
+++ b/src/app/pages/WrongQuizPage.tsx
@@ -1,0 +1,675 @@
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import type { ChangeEvent } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { Header, Footer, LoginModal, Icon, Modal, Input } from '@/components';
+import { authUtils } from '@/lib/auth';
+import { getWrongQuizzes, updateQuizzesTopic } from '@/api/quiz';
+import type {
+  WrongQuizGroupResponse,
+  WrongQuizHistoryDetail,
+  WrongQuizGroup,
+} from '@/types/quiz';
+
+const GROUP_TYPE_OPTIONS: Array<{ label: string; value: 'date' | 'topic' }> = [
+  { label: '날짜순', value: 'date' },
+  { label: '주제순', value: 'topic' },
+];
+
+const GROUP_TYPE_LABEL: Record<'date' | 'topic', string> = {
+  date: '날짜순',
+  topic: '주제순',
+};
+
+const WrongQuizPage = () => {
+  const navigate = useNavigate();
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+  const [groupType, setGroupType] = useState<'date' | 'topic'>('date');
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(() =>
+    authUtils.isAuthenticated()
+  );
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const desktopDropdownRef = useRef<HTMLDivElement | null>(null);
+  const mobileDropdownRef = useRef<HTMLDivElement | null>(null);
+  const [activeMenuGroup, setActiveMenuGroup] = useState<string | null>(null);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [targetGroup, setTargetGroup] = useState<WrongQuizGroup | null>(null);
+  const [topicInput, setTopicInput] = useState('');
+  const [formMessage, setFormMessage] = useState<{
+    type: 'error' | 'success';
+    text: string;
+  } | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isTopicEdited, setIsTopicEdited] = useState(false);
+
+  const handleOpenLoginModal = useCallback(() => {
+    setIsLoginModalOpen(true);
+  }, []);
+
+  const handleCloseLoginModal = useCallback(() => {
+    setIsLoginModalOpen(false);
+  }, []);
+
+  const {
+    data,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery<WrongQuizGroupResponse, Error>({
+    queryKey: ['wrong-quizzes', groupType],
+    queryFn: () => getWrongQuizzes(groupType),
+    enabled: isAuthenticated,
+    staleTime: 1000 * 60 * 5,
+    refetchOnMount: 'always',
+  });
+
+  const quizGroups = useMemo(() => data?.quizGroupList ?? [], [data]);
+  const targetQuizCount = targetGroup?.quizHistoryDetailList.length ?? 0;
+  const trimmedTopicInput = topicInput.trim();
+  const cardBaseClass =
+    'relative w-full max-w-[312px] h-[144px] rounded-[12px] border border-[#dedede] bg-white px-4 pt-10 pb-4 text-left shadow-[0_12px_30px_rgba(0,0,0,0.06)] transition-[transform,box-shadow] hover:-translate-y-1 hover:shadow-[0_16px_32px_rgba(0,0,0,0.1)] flex flex-col justify-between';
+  const isSubmitDisabled =
+    !targetGroup ||
+    !trimmedTopicInput ||
+    trimmedTopicInput === targetGroup.group ||
+    isSubmitting ||
+    targetQuizCount === 0;
+
+  useEffect(() => {
+    if (!error) return;
+    const isAuthError =
+      error.message.includes('로그인이 필요') || error.message.includes('인증');
+    if (isAuthError) {
+      authUtils.logout();
+      setIsAuthenticated(false);
+      setIsLoginModalOpen(true);
+    }
+  }, [error]);
+
+  useEffect(() => {
+    if (!isDropdownOpen) return;
+    if (typeof document === 'undefined') return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const refs = [desktopDropdownRef, mobileDropdownRef];
+      const shouldClose = refs.every(
+        (ref) => !ref.current || !ref.current.contains(event.target as Node)
+      );
+
+      if (shouldClose) {
+        setIsDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isDropdownOpen]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+
+    const handleMenuClose = () => {
+      setActiveMenuGroup(null);
+    };
+
+    document.addEventListener('click', handleMenuClose);
+    return () => {
+      document.removeEventListener('click', handleMenuClose);
+    };
+  }, []);
+
+  const handleGroupTypeChange = useCallback((value: 'date' | 'topic') => {
+    setGroupType(value);
+    setIsDropdownOpen(false);
+    setActiveMenuGroup(null);
+  }, []);
+
+  const handleDropdownToggle = useCallback(() => {
+    setIsDropdownOpen((prev) => !prev);
+  }, []);
+
+  const handleTopicInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setTopicInput(event.target.value);
+      setIsTopicEdited(true);
+      if (formMessage) {
+        setFormMessage(null);
+      }
+    },
+    [formMessage]
+  );
+
+  const handleOpenEditModal = useCallback((group: WrongQuizGroup) => {
+    setTargetGroup(group);
+    setTopicInput(group.group);
+    setFormMessage(null);
+    setIsEditModalOpen(true);
+    setActiveMenuGroup(null);
+    setIsTopicEdited(false);
+  }, []);
+
+  const handleCloseEditModal = useCallback(() => {
+    setIsEditModalOpen(false);
+    setTargetGroup(null);
+    setTopicInput('');
+    setFormMessage(null);
+    setIsSubmitting(false);
+    setIsTopicEdited(false);
+  }, []);
+
+  const handleTopicSubmit = useCallback(async () => {
+    if (!targetGroup) return;
+    const nextTopic = trimmedTopicInput;
+
+    if (!nextTopic) {
+      setFormMessage({ type: 'error', text: '주제를 입력해주세요.' });
+      return;
+    }
+
+    if (targetQuizCount === 0) {
+      setFormMessage({ type: 'error', text: '수정할 문제가 없어요.' });
+      return;
+    }
+
+    if (nextTopic === targetGroup.group) {
+      setFormMessage({ type: 'error', text: '변경된 내용이 없어요.' });
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await updateQuizzesTopic({
+        topic: nextTopic,
+        quizIdList: targetGroup.quizHistoryDetailList.map((quiz) => quiz.quizId),
+      });
+      setFormMessage({ type: 'success', text: '주제를 수정했어요!' });
+      await refetch();
+
+      setTimeout(() => {
+        handleCloseEditModal();
+      }, 800);
+    } catch (submitError) {
+      setFormMessage({
+        type: 'error',
+        text:
+          submitError instanceof Error
+            ? submitError.message
+            : '주제 수정 중 문제가 발생했어요.',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    handleCloseEditModal,
+    refetch,
+    targetGroup,
+    targetQuizCount,
+    trimmedTopicInput,
+  ]);
+
+  const handleCardClick = useCallback(
+    (quizzes: WrongQuizHistoryDetail[]) => {
+      if (!quizzes.length) return;
+      navigate('/wrong-quizzes/solve', {
+        state: { quizzes },
+      });
+    },
+    [navigate]
+  );
+
+  const renderContent = (gridClassName: string) => {
+    if (isLoading) {
+      return (
+        <div className="flex flex-col items-center justify-center py-20">
+          <div className="w-12 h-12 border-4 border-primary border-t-transparent rounded-full animate-spin mb-4" />
+          <p className="text-body1-medium text-gray-600">로딩 중...</p>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className="flex flex-col items-center justify-center py-20">
+          <p className="text-body1-medium text-error mb-4">
+            {error.message || '데이터를 불러오는 중 오류가 발생했어요.'}
+          </p>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="bg-primary text-white text-body3-regular px-l py-3 rounded-[6px] hover:bg-primary/90 transition-colors"
+          >
+            다시 시도
+          </button>
+        </div>
+      );
+    }
+
+    if (!quizGroups.length) {
+      return (
+        <div className="w-full rounded-[12px] border border-[#dedede] bg-white px-8 py-10 text-left shadow-[0_8px_24px_rgba(0,0,0,0.04)]">
+          <p className="text-body1-medium text-gray-900 mb-2">
+            최근 틀린 문제가 아직 없어요.
+          </p>
+          <p className="text-body2-regular text-gray-600">
+            문제를 풀고 다시 도전할 틀린 문제를 모아볼 수 있어요.
+          </p>
+        </div>
+      );
+    }
+
+    if (groupType === 'topic') {
+      return (
+        <div className={gridClassName}>
+          {quizGroups.map((group) => {
+            const quizCount = group.quizHistoryDetailList.length;
+            return (
+              <button
+                key={`${group.group}-topic`}
+                type="button"
+                onClick={() => handleCardClick(group.quizHistoryDetailList)}
+                className={cardBaseClass}
+              >
+                <div className="mb-6 flex items-center justify-center gap-3 text-center">
+                  <Icon name="icn_note" size={24} />
+                  <span className="text-[20px] font-medium text-gray-900 truncate max-w-[220px]">
+                    {group.group}
+                  </span>
+                  <button
+                    type="button"
+                    aria-label={`${group.group} 더보기`}
+                    className="absolute right-4 top-4 flex h-6 w-6 items-center justify-center rounded-full text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      setActiveMenuGroup((prev) =>
+                        prev === group.group ? null : group.group
+                      );
+                    }}
+                  >
+                    <svg width="18" height="4" viewBox="0 0 18 4" fill="none">
+                      <circle cx="2" cy="2" r="2" fill="currentColor" />
+                      <circle cx="9" cy="2" r="2" fill="currentColor" />
+                      <circle cx="16" cy="2" r="2" fill="currentColor" />
+                    </svg>
+                  </button>
+
+                  {activeMenuGroup === group.group && (
+                    <div
+                      className="absolute right-0 top-10 z-30"
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      <div className="w-[170px] rounded-[10px] border border-[#dedede] bg-white p-2 shadow-[0_12px_30px_rgba(0,0,0,0.08)]">
+                        <button
+                          type="button"
+                          className="w-full rounded-[6px] px-3 py-2 text-left text-body3-medium text-gray-900 hover:bg-gray-50"
+                          onClick={(event) => {
+                            event.preventDefault();
+                            handleOpenEditModal(group);
+                          }}
+                        >
+                          주제 수정하기
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                <div className="mt-auto flex justify-end">
+                  <div className="inline-flex h-[36px] min-w-[105px] items-center justify-center rounded-[6px] bg-[#f6fbf4] px-3">
+                    <span className="inline-flex min-w-[81px] h-[20px] items-center justify-center text-body3-regular text-primary">
+                      틀린문제 {quizCount}개
+                    </span>
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      );
+    }
+
+    return (
+      <div className={gridClassName}>
+        {quizGroups.map((group) => (
+          <button
+            key={`${group.group}-date`}
+            type="button"
+            onClick={() => handleCardClick(group.quizHistoryDetailList)}
+            className={cardBaseClass}
+          >
+            <div className="mb-6 flex items-center justify-center gap-3 text-center">
+              <Icon name="calendar" size={24} />
+              <span className="text-[20px] font-medium text-gray-900">
+                {group.group}
+              </span>
+            </div>
+            <div className="mt-auto flex justify-end">
+              <div className="inline-flex h-[36px] min-w-[105px] items-center justify-center rounded-[6px] bg-[#f6fbf4] px-3">
+                <span className="inline-flex min-w-[81px] h-[20px] items-center justify-center text-body3-regular text-primary">
+                  틀린문제 {group.quizHistoryDetailList.length}개
+                </span>
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+    );
+  };
+
+  // 비회원인 경우 - 로그인 요구 페이지 표시
+  if (!isAuthenticated) {
+    return (
+      <div className="min-h-screen bg-bg-home flex flex-col">
+        <Header logoUrl="/logo.svg" onLoginClick={handleOpenLoginModal} />
+
+        {/* Main Content - Web/Tablet */}
+        <main className="flex-1 flex flex-col items-center justify-center px-6 max-md:hidden">
+          {/* Character Images */}
+          <div className="flex gap-[15px] mb-10">
+            <img
+              src="/characters/character1.png"
+              alt="캐릭터 1"
+              className="w-[72px] h-[72px]"
+            />
+            <img
+              src="/characters/character2.png"
+              alt="캐릭터 2"
+              className="w-[79px] h-[72px]"
+            />
+            <img
+              src="/characters/character3.png"
+              alt="캐릭터 3"
+              className="w-[72px] h-[72px]"
+            />
+            <img
+              src="/characters/character4.png"
+              alt="캐릭터 4"
+              className="w-[72px] h-[72px]"
+            />
+          </div>
+
+          {/* Title */}
+          <h1 className="text-header1-bold text-gray-900 text-center mb-4">
+            틀린 문제를 확인하려면 회원가입 또는 로그인이 필요해요
+          </h1>
+
+          {/* Description */}
+          <p className="text-body1-regular text-gray-600 text-center mb-10">
+            퀴즐리 계정이 없다면 지금 바로 회원가입을 해보세요.
+          </p>
+
+          {/* Sign Up Button */}
+          <button
+            onClick={handleOpenLoginModal}
+            className="bg-primary text-white text-body3-regular px-l py-4 rounded-[6px] hover:bg-primary/90 transition-colors"
+          >
+            지금 가입하기
+          </button>
+        </main>
+
+        {/* Main Content - Mobile */}
+        <main className="hidden max-md:flex flex-1 flex-col items-center justify-center px-5">
+          {/* Character Images */}
+          <div className="flex gap-[7px] mb-6">
+            <img
+              src="/characters/character1.png"
+              alt="캐릭터 1"
+              className="w-[60px] h-[60px]"
+            />
+            <img
+              src="/characters/character2.png"
+              alt="캐릭터 2"
+              className="w-[66px] h-[60px]"
+            />
+            <img
+              src="/characters/character3.png"
+              alt="캐릭터 3"
+              className="w-[60px] h-[60px]"
+            />
+            <img
+              src="/characters/character4.png"
+              alt="캐릭터 4"
+              className="w-[60px] h-[60px]"
+            />
+          </div>
+
+          {/* Title */}
+          <h1 className="text-header3-bold text-gray-900 text-center mb-3">
+            틀린 문제를 확인하려면 회원가입
+            <br />
+            또는 로그인이 필요해요
+          </h1>
+
+          {/* Description */}
+          <p className="text-body3-regular text-gray-600 text-center mb-8">
+            퀴즐리 계정이 없다면 지금 바로 회원가입을 해보세요.
+          </p>
+
+          {/* Sign Up Button */}
+          <button
+            onClick={handleOpenLoginModal}
+            className="bg-primary text-white text-body3-regular px-l py-[14px] rounded-[6px] hover:bg-primary/90 transition-colors"
+          >
+            지금 가입하기
+          </button>
+        </main>
+
+        {/* Footer - Web/Tablet Only */}
+        <div className="max-md:hidden">
+          <Footer />
+        </div>
+
+        {/* Login Modal */}
+        <LoginModal isOpen={isLoginModalOpen} onClose={handleCloseLoginModal} />
+      </div>
+    );
+  }
+
+  // 회원인 경우 - 틀린문제 목록 표시
+  return (
+    <div className="min-h-screen bg-bg-home flex flex-col">
+      <Header logoUrl="/logo.svg" onLoginClick={handleOpenLoginModal} />
+
+      {/* Main Content - Web/Tablet */}
+      <main className="flex-1 flex flex-col items-center pt-20 pb-24 px-[60px] max-md:hidden">
+        <div className="w-full max-w-[1024px]">
+          <div className="flex flex-col gap-6 mb-12">
+            <div className="flex items-center justify-center gap-3 text-center">
+              <h1 className="text-header1-bold text-gray-900">
+                <span className="text-primary">틀린문제</span> 다시 한번 풀어봐요
+              </h1>
+              <Icon name="icn_checkbox" size={40} />
+            </div>
+          </div>
+
+          <div className="flex justify-end mb-8">
+            <div className="relative w-[140px]" ref={desktopDropdownRef}>
+              <button
+                type="button"
+                onClick={handleDropdownToggle}
+                className="flex w-full items-center justify-between rounded-[6px] border border-[#dedede] bg-white py-3 px-4 text-left text-body2-regular text-gray-900 hover:border-primary focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                aria-haspopup="listbox"
+                aria-expanded={isDropdownOpen}
+              >
+                {GROUP_TYPE_LABEL[groupType]}
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  className={`text-gray-600 transition-transform ${
+                    isDropdownOpen ? 'rotate-180' : ''
+                  }`}
+                >
+                  <path
+                    d="M6 9l6 6 6-6"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+
+              {isDropdownOpen && (
+                <div className="absolute right-0 top-[calc(100%+8px)] z-20 w-full rounded-[10px] border border-[#dedede] bg-white shadow-[0_12px_30px_rgba(0,0,0,0.08)]">
+                  {GROUP_TYPE_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => handleGroupTypeChange(option.value)}
+                      className={`w-full px-4 py-3 text-left text-body3-medium transition-colors ${
+                        option.value === groupType
+                          ? 'text-primary'
+                          : 'text-gray-900 hover:bg-gray-50'
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-5">
+            {renderContent('grid grid-cols-3 gap-4 max-md:grid-cols-2')}
+          </div>
+        </div>
+      </main>
+
+      {/* Main Content - Mobile */}
+      <main className="hidden max-md:flex flex-1 flex-col pt-[74px] pb-[120px] px-5">
+        <div className="flex flex-col items-center gap-2 mb-8">
+          <div className="flex items-center gap-2">
+            <h1 className="text-header3-bold text-gray-900">
+              <span className="text-primary">틀린문제</span> 다시 한번
+            </h1>
+            <Icon name="icn_checkbox" size={32} />
+          </div>
+          <h1 className="text-header3-bold text-gray-900">풀어봐요</h1>
+        </div>
+
+        <div className="flex justify-end mb-6">
+          <div className="relative w-[140px]" ref={mobileDropdownRef}>
+            <button
+              type="button"
+              onClick={handleDropdownToggle}
+              className="flex w-full items-center justify-between rounded-[6px] border border-[#dedede] bg-white py-3 px-4 text-left text-body3-medium text-gray-900 hover:border-primary focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              aria-haspopup="listbox"
+              aria-expanded={isDropdownOpen}
+            >
+              {GROUP_TYPE_LABEL[groupType]}
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                className={`text-gray-600 transition-transform ${
+                  isDropdownOpen ? 'rotate-180' : ''
+                }`}
+              >
+                <path
+                  d="M6 9l6 6 6-6"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+
+            {isDropdownOpen && (
+              <div className="absolute right-0 top-[calc(100%+8px)] z-20 w-full rounded-[10px] border border-[#dedede] bg-white shadow-[0_12px_30px_rgba(0,0,0,0.08)]">
+                {GROUP_TYPE_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => handleGroupTypeChange(option.value)}
+                    className={`w-full px-4 py-3 text-left text-body3-medium transition-colors ${
+                      option.value === groupType
+                        ? 'text-primary'
+                        : 'text-gray-900 hover:bg-gray-50'
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-4 w-full">
+          {renderContent('grid grid-cols-2 gap-3 w-full')}
+        </div>
+      </main>
+
+      <div className="max-md:hidden">
+        <Footer />
+      </div>
+
+      <LoginModal isOpen={isLoginModalOpen} onClose={handleCloseLoginModal} />
+
+      <Modal isOpen={isEditModalOpen} onClose={handleCloseEditModal}>
+        <div className="w-full max-w-[430px]">
+          <div className="flex flex-col gap-6">
+            <h2 className="text-center text-header3-bold text-gray-900">
+              주제 수정하기
+            </h2>
+
+            <div className="flex flex-col gap-3">
+              <div className="mx-auto w-[350px]">
+                <Input
+                  label="새로운 주제"
+                  placeholder={targetGroup?.group ?? '새로운 주제를 입력하세요'}
+                  value={topicInput}
+                  onChange={handleTopicInputChange}
+                  labelClassName="text-left"
+                  inputClassName={`${
+                    !isTopicEdited ? '!text-gray-500 !placeholder:text-gray-400' : ''
+                  }`}
+                  className="w-full"
+                />
+              </div>
+              {formMessage && (
+                <p
+                  className={`text-body3-medium ${
+                    formMessage.type === 'error' ? 'text-error' : 'text-primary'
+                  }`}
+                >
+                  {formMessage.text}
+                </p>
+              )}
+            </div>
+
+            <div className="mt-2 flex items-center justify-center gap-3">
+              <button
+                type="button"
+                onClick={handleCloseEditModal}
+                className="h-[46px] w-[120px] rounded-[6px] border border-[#dedede] bg-[#efefef] text-body3-medium text-gray-900 hover:bg-gray-200 disabled:opacity-60"
+                disabled={isSubmitting}
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={handleTopicSubmit}
+                disabled={isSubmitDisabled}
+                className="h-[46px] w-[120px] rounded-[6px] bg-primary text-body3-medium text-white transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSubmitting ? '수정 중...' : '수정하기'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+WrongQuizPage.displayName = 'WrongQuizPage';
+
+export default WrongQuizPage;

--- a/src/app/pages/WrongQuizSolvePage.tsx
+++ b/src/app/pages/WrongQuizSolvePage.tsx
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import QuizSolvePage from '@/app/pages/QuizSolvePage';
+import type {
+  QuizDetail,
+  WrongQuizHistoryDetail,
+  UserAnswer,
+} from '@/types/quiz';
+
+type WrongQuizSolveState = {
+  quizzes?: WrongQuizHistoryDetail[];
+};
+
+const WrongQuizSolvePage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const queryClient = useQueryClient();
+
+  const quizzes = (location.state as WrongQuizSolveState | undefined)?.quizzes;
+
+  useEffect(() => {
+    if (!quizzes || quizzes.length === 0) {
+      navigate('/wrong-quizzes', { replace: true });
+    }
+  }, [navigate, quizzes]);
+
+  const quizDetailList = useMemo<QuizDetail[]>(() => {
+    if (!quizzes) return [];
+    return quizzes.map((quiz) => ({
+      quizId: quiz.quizId,
+      text: quiz.text,
+      type: quiz.type,
+      options: quiz.options ?? [],
+      answer: quiz.answer,
+      explanation: quiz.explanation,
+      topic: quiz.topic,
+    }));
+  }, [quizzes]);
+
+  if (!quizzes || quizzes.length === 0) {
+    return null;
+  }
+
+  const invalidateWrongQuizQueries = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ['wrong-quizzes'] });
+  }, [queryClient]);
+
+  const handleComplete = useCallback(
+    async (_answers: UserAnswer[]) => {
+      await invalidateWrongQuizQueries();
+      navigate('/wrong-quizzes', { replace: true });
+    },
+    [invalidateWrongQuizQueries, navigate]
+  );
+
+  const handleViewAll = useCallback(
+    async (_answers: UserAnswer[]) => {
+      await invalidateWrongQuizQueries();
+      navigate('/my-quizzes', { replace: true });
+    },
+    [invalidateWrongQuizQueries, navigate]
+  );
+
+  const handleExit = useCallback(async () => {
+    await invalidateWrongQuizQueries();
+    navigate('/', { replace: true });
+  }, [invalidateWrongQuizQueries, navigate]);
+
+  return (
+    <QuizSolvePage
+      quizDetailList={quizDetailList}
+      onComplete={handleComplete}
+      onExit={handleExit}
+      onViewAll={handleViewAll}
+    />
+  );
+};
+
+WrongQuizSolvePage.displayName = 'WrongQuizSolvePage';
+
+export default WrongQuizSolvePage;
+

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -3,6 +3,8 @@ import HomePage from '@/app/pages/HomePage';
 import AuthCallback from '@/app/pages/AuthCallback';
 import QuizListPage from '@/app/pages/QuizListPage';
 import QuizDetailPage from '@/app/pages/QuizDetailPage';
+import WrongQuizPage from '@/app/pages/WrongQuizPage';
+import WrongQuizSolvePage from '@/app/pages/WrongQuizSolvePage';
 
 export const router = createBrowserRouter([
   {
@@ -16,6 +18,14 @@ export const router = createBrowserRouter([
   {
     path: '/my-quizzes/:date',
     element: <QuizDetailPage />,
+  },
+  {
+    path: '/wrong-quizzes',
+    element: <WrongQuizPage />,
+  },
+  {
+    path: '/wrong-quizzes/solve',
+    element: <WrongQuizSolvePage />,
   },
   {
     path: '/login/oauth2/code/:provider',

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -26,7 +26,9 @@ type IconName =
   | "check_black"
   | "check_blue"
   | "check_red"
-  | "check_green";
+  | "check_green"
+  | "icn_checkbox"
+  | "icn_note";
 
 type IconProps = {
   name: IconName;
@@ -363,6 +365,24 @@ const Icon = ({ name, size = 28, className = "", onClick }: IconProps) => {
       <img
         src="/icon/check_green.svg"
         alt="check_green"
+        width={size}
+        height={size}
+        className={className}
+      />
+    ),
+    icn_checkbox: (
+      <img
+        src="/icon/icn_checkbox.svg"
+        alt="icn_checkbox"
+        width={size}
+        height={size}
+        className={className}
+      />
+    ),
+    icn_note: (
+      <img
+        src="/icon/icn_note.svg"
+        alt="icn_note"
         width={size}
         height={size}
         className={className}

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -10,6 +10,8 @@ type InputProps = {
   disabled?: boolean;
   type?: 'text' | 'email' | 'password' | 'number';
   className?: string;
+  labelClassName?: string;
+  inputClassName?: string;
 };
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
@@ -23,6 +25,8 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       disabled = false,
       type = 'text',
       className = '',
+      labelClassName = '',
+      inputClassName = '',
     },
     ref
   ) => {
@@ -35,7 +39,11 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className={`flex flex-col gap-xs w-full ${className}`}>
         {label && (
-          <label className="text-body3-regular text-gray-600">{label}</label>
+          <label
+            className={`text-body3-regular text-gray-600 ${labelClassName}`}
+          >
+            {label}
+          </label>
         )}
 
         <input
@@ -45,7 +53,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           onChange={onChange}
           placeholder={placeholder}
           disabled={disabled}
-          className={inputStyles}
+          className={`${inputStyles} ${inputClassName}`}
         />
 
         {error && (

--- a/src/components/common/MemberOnlyPage.tsx
+++ b/src/components/common/MemberOnlyPage.tsx
@@ -1,0 +1,163 @@
+import { Header, Footer, LoginModal } from '@/components';
+
+type MemberOnlyPageProps = {
+  variant?: 'full' | 'simple';
+  isLoginModalOpen: boolean;
+  onOpenLoginModal: () => void;
+  onCloseLoginModal: () => void;
+};
+
+const MemberOnlyPage = ({
+  variant = 'full',
+  isLoginModalOpen,
+  onOpenLoginModal,
+  onCloseLoginModal,
+}: MemberOnlyPageProps) => {
+  if (variant === 'simple') {
+    return (
+      <div className="min-h-screen bg-bg-home flex flex-col">
+        <Header logoUrl="/logo.svg" onLoginClick={onOpenLoginModal} />
+
+        <main className="flex-1 flex flex-col items-center justify-center px-6">
+          <h1 className="text-header1-bold text-gray-900 text-center mb-4 max-md:text-header3-bold">
+            이 페이지는 비회원 전용입니다
+          </h1>
+          <p className="text-body1-regular text-gray-600 text-center mb-10 max-md:text-body3-regular">
+            회원은 이 페이지에 접근할 수 없습니다.
+            <br />
+            로그아웃 후 이용해주세요.
+          </p>
+          <button
+            onClick={() => (window.location.href = '/')}
+            className="bg-primary text-white text-body3-regular px-l py-4 rounded-[6px] hover:bg-primary/90 transition-colors"
+          >
+            홈으로 돌아가기
+          </button>
+        </main>
+
+        <div className="max-md:hidden">
+          <Footer />
+        </div>
+
+        <LoginModal isOpen={isLoginModalOpen} onClose={onCloseLoginModal} />
+      </div>
+    );
+  }
+
+  // Full variant with characters
+  return (
+    <div className="min-h-screen bg-bg-home flex flex-col">
+      <Header logoUrl="/logo.svg" onLoginClick={onOpenLoginModal} />
+
+      {/* Main Content - Web/Tablet */}
+      <main className="flex-1 flex flex-col items-center justify-center px-6 max-md:hidden">
+        {/* Character Images */}
+        <div className="flex gap-[15px] mb-10">
+          <img
+            src="/characters/character1.png"
+            alt="캐릭터 1"
+            className="w-[72px] h-[72px]"
+          />
+          <img
+            src="/characters/character2.png"
+            alt="캐릭터 2"
+            className="w-[79px] h-[72px]"
+          />
+          <img
+            src="/characters/character3.png"
+            alt="캐릭터 3"
+            className="w-[72px] h-[72px]"
+          />
+          <img
+            src="/characters/character4.png"
+            alt="캐릭터 4"
+            className="w-[72px] h-[72px]"
+          />
+        </div>
+
+        {/* Title */}
+        <h1 className="text-header1-bold text-gray-900 text-center mb-4">
+          이 페이지는 비회원 전용입니다
+        </h1>
+
+        {/* Description */}
+        <p className="text-body1-regular text-gray-600 text-center mb-10">
+          회원은 이 페이지에 접근할 수 없습니다.
+          <br />
+          로그아웃 후 이용해주세요.
+        </p>
+
+        {/* Home Button */}
+        <button
+          onClick={() => (window.location.href = '/')}
+          className="bg-primary text-white text-body3-regular px-l py-4 rounded-[6px] hover:bg-primary/90 transition-colors"
+        >
+          홈으로 돌아가기
+        </button>
+      </main>
+
+      {/* Main Content - Mobile */}
+      <main className="hidden max-md:flex flex-1 flex-col items-center justify-center px-5">
+        {/* Character Images */}
+        <div className="flex gap-[7px] mb-6">
+          <img
+            src="/characters/character1.png"
+            alt="캐릭터 1"
+            className="w-[60px] h-[60px]"
+          />
+          <img
+            src="/characters/character2.png"
+            alt="캐릭터 2"
+            className="w-[66px] h-[60px]"
+          />
+          <img
+            src="/characters/character3.png"
+            alt="캐릭터 3"
+            className="w-[60px] h-[60px]"
+          />
+          <img
+            src="/characters/character4.png"
+            alt="캐릭터 4"
+            className="w-[60px] h-[60px]"
+          />
+        </div>
+
+        {/* Title */}
+        <h1 className="text-header3-bold text-gray-900 text-center mb-3">
+          이 페이지는 비회원 전용입니다
+        </h1>
+
+        {/* Description */}
+        <p className="text-body3-regular text-gray-600 text-center mb-8">
+          회원은 이 페이지에 접근할 수 없습니다.
+          <br />
+          로그아웃 후 이용해주세요.
+        </p>
+
+        {/* Home Button */}
+        <button
+          onClick={() => (window.location.href = '/')}
+          className="bg-primary text-white text-body3-regular px-l py-[14px] rounded-[6px] hover:bg-primary/90 transition-colors"
+        >
+          홈으로 돌아가기
+        </button>
+      </main>
+
+      {/* Footer - Web/Tablet Only */}
+      <div className="max-md:hidden">
+        <Footer />
+      </div>
+
+      {/* Login Modal */}
+      <LoginModal isOpen={isLoginModalOpen} onClose={onCloseLoginModal} />
+    </div>
+  );
+};
+
+MemberOnlyPage.displayName = 'MemberOnlyPage';
+
+export default MemberOnlyPage;
+
+
+
+

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -14,7 +14,7 @@ const Modal = ({ isOpen, onClose, children }: ModalProps) => {
       onClose={onClose}
       className="flex items-center justify-center"
     >
-      <div className="bg-white rounded-[24px] p-8 max-w-[450px] w-full mx-m outline-none">
+      <div className="bg-white rounded-[24px] pt-[60px] pr-8 pb-8 pl-8 w-[430px] min-h-[324px] mx-m outline-none">
         {children}
       </div>
     </MuiModal>
@@ -75,22 +75,11 @@ export const QuizResultModal = ({
         <div className="flex flex-col items-center gap-4">
           {/* Success Icon */}
           <div className="w-[100px] h-[100px] flex items-center justify-center">
-            <svg
-              width="100"
-              height="100"
-              viewBox="0 0 100 100"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <circle cx="50" cy="50" r="40" className="fill-primary opacity-10" />
-              <path
-                d="M35 50L45 60L65 40"
-                className="stroke-primary"
-                strokeWidth="4"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            <img
+              src="/icon/group.svg"
+              alt="그룹 아이콘"
+              className="w-full h-full object-contain"
+            />
           </div>
 
           <p className="text-body3-medium text-primary">

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,3 +9,4 @@ export { default as ProgressBar } from "./common/ProgressBar";
 export { default as DateCard } from "./common/DateCard";
 export { default as QuizCard } from "./common/QuizCard";
 export { default as UnauthorizedPage } from "./common/UnauthorizedPage";
+export { default as MemberOnlyPage } from "./common/MemberOnlyPage";

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -54,3 +54,34 @@ export type QuizGroupResponse = {
   errorCode: string | null;
   quizGroupList: QuizGroup[];
 };
+
+// 틀린 문제 조회 API 타입
+export type WrongQuizHistoryDetail = {
+  quizId: number;
+  text: string;
+  type: QuizType;
+  options: string[];
+  answer: string;
+  explanation: string;
+  topic: string;
+  isCorrect: boolean;
+};
+
+export type WrongQuizGroup = {
+  group: string;
+  quizHistoryDetailList: WrongQuizHistoryDetail[];
+};
+
+export type WrongQuizGroupResponse = {
+  quizGroupList: WrongQuizGroup[];
+};
+
+export type UpdateQuizzesTopicRequest = {
+  topic: string;
+  quizIdList: number[];
+};
+
+export type UpdateQuizzesTopicResponse = {
+  success: boolean;
+  errorCode?: string | null;
+};


### PR DESCRIPTION
- 연관 이슈

  이 PR이 해결하는 이슈: Closes #11  (병합 시 자동으로 이슈 닫힘)
- 구현 내용
  - 틀린 문제 풀어보기 페이지 주제/날짜 순 모두 구현 완료
  - 오답 풀이 시 결과 모달창이 일반 문제 풀이와 동일하게 나오도록 구현
  - 틀린 문제 개수 반영 이슈는 백엔드에서 해결하는 것으로 결정->반영 시 올바르게 개수 변화하는 것 확인
 
- 기타 이슈
  - header의 문제 만들기 클릭 시 메인 홈으로 넘어가지 않음. 연결이 아예 안된 상태
  - 일반 문제 풀이에서 결과 모달 창이 나오지 않는 것을 확인
 

- 테스트
 - 주제/날짜 순, 주제 수정하기 , 태블릿/모바일 반응형 구조 통일 모두 테스트 완료