### PR TITLE
bug(#15): 틀린문제 풀어보기 날짜순 조회 정렬 수정

### DIFF
--- a/src/app/pages/WrongQuizPage.tsx
+++ b/src/app/pages/WrongQuizPage.tsx
@@ -63,7 +63,14 @@ const WrongQuizPage = () => {
     refetchOnMount: 'always',
   });
 
-  const quizGroups = useMemo(() => data?.quizGroupList ?? [], [data]);
+  const quizGroups = useMemo(() => {
+    const groups = data?.quizGroupList ?? [];
+    // 날짜순일 때 최신순 정렬 적용
+    if (groupType === 'date') {
+      return [...groups].sort((a, b) => b.group.localeCompare(a.group));
+    }
+    return groups;
+  }, [data, groupType]);
   const targetQuizCount = targetGroup?.quizHistoryDetailList.length ?? 0;
   const trimmedTopicInput = topicInput.trim();
   const cardBaseClass =


### PR DESCRIPTION
- 연관 이슈
  - 이 PR이 해결하는 이슈: Closes #15  (병합 시 자동으로 이슈 닫힘)
- 원인
  - API 응답값을 그대로 렌더링하여 최신순으로 정렬되지 않았음
  - 날짜 순인 경우 최신순으로 정렬하도록 수정
- 테스트
  - 웹
    <img width="2517" height="1391" alt="image" src="https://github.com/user-attachments/assets/7b04a799-4399-4585-ae7c-d06ecdc70171" />
  - 태블릿  
    <img width="753" height="998" alt="image" src="https://github.com/user-attachments/assets/dd2926d4-a8b7-4ac2-9220-0e2ffd8c695b" />

  - 모바일
    <img width="575" height="1247" alt="image" src="https://github.com/user-attachments/assets/23d152db-32d6-4957-8e6a-3a07c1fd0a28" />

