### PR TITLE
feat(#17): 헤더/푸터 사이즈 수정 및 로고 라우팅 추가

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,34 +1,34 @@
 const Footer = () => {
   return (
-    <footer className="w-full bg-bg-footer">
-      <div className="py-10 flex items-center justify-center">
-        <div className="max-w-[1024px] w-full px-xl max-lg:px-15 flex items-center justify-center gap-3 max-md:hidden">
+    <footer className="w-full bg-bg-footer h-[80px]">
+      <div className="h-full flex items-center justify-center">
+        <div className="max-w-[1024px] w-full px-xl max-lg:px-15 flex items-center justify-center gap-3 max-lg:gap-[clamp(6px,1.2vw,12px)] max-md:hidden whitespace-nowrap">
           <a
             href="https://www.notion.so/2480d810a5198028a431f471d3327ce0?source=copy_link"
-            className="text-footer text-gray-600 px-s py-xs"
+            className="text-[14px] max-lg:text-[clamp(12px,1.5vw,14px)] text-gray-600 px-s py-xs leading-[1.4] shrink-0"
           >
             이용약관
           </a>
 
           <a
             href="/privacy"
-            className="text-footer text-gray-600 px-s py-xs"
+            className="text-[14px] max-lg:text-[clamp(12px,1.5vw,14px)] text-gray-600 px-s py-xs leading-[1.4] shrink-0"
           >
             개인정보처리방침
           </a>
 
-          <p className="text-footer text-gray-600 px-s py-xs">
+          <p className="text-[14px] max-lg:text-[clamp(12px,1.5vw,14px)] text-gray-600 px-s py-xs leading-[1.4] shrink-0">
             Team. 에스F레소
           </p>
 
           <a
             href="mailto:liz021229@gmail.com"
-            className="text-footer text-gray-600 px-s py-xs"
+            className="text-[14px] max-lg:text-[clamp(12px,1.5vw,14px)] text-gray-600 px-s py-xs leading-[1.4] shrink-0"
           >
             문의: liz021229@gmail.com
           </a>
 
-          <p className="text-footer text-gray-600 px-s py-xs">
+          <p className="text-[14px] max-lg:text-[clamp(12px,1.5vw,14px)] text-gray-600 px-s py-xs leading-[1.4] shrink-0">
             © 2025 Quizly. All rights reserved.
           </p>
         </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,13 +1,13 @@
-import { useState, useEffect, useCallback } from 'react';
-import { Button } from '@/components';
-import { authUtils } from '@/lib/auth';
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components";
+import { authUtils } from "@/lib/auth";
 
 type HeaderProps = {
   logoUrl?: string;
   onLoginClick?: () => void;
 };
 
-const Header = ({ logoUrl = '/logo.svg', onLoginClick }: HeaderProps) => {
+const Header = ({ logoUrl = "/logo.svg", onLoginClick }: HeaderProps) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
   useEffect(() => {
@@ -18,7 +18,7 @@ const Header = ({ logoUrl = '/logo.svg', onLoginClick }: HeaderProps) => {
     if (onLoginClick) {
       onLoginClick();
     } else {
-      window.location.href = '/login';
+      window.location.href = "/login";
     }
   }, [onLoginClick]);
 
@@ -33,43 +33,54 @@ const Header = ({ logoUrl = '/logo.svg', onLoginClick }: HeaderProps) => {
       {/* Desktop/Tablet Header */}
       <div className="h-[90px] max-lg:h-[72px] max-md:hidden">
         <div className="max-w-[1200px] mx-auto h-full flex items-center justify-between px-xl max-lg:px-15">
-          <div className="flex items-center">
+          <a href="/" className="flex items-center shrink-0">
             <img
               src={logoUrl}
               alt="Quizly Logo"
-              className="h-[32px] w-[120px]"
+              className="h-[32px] w-[120px] max-lg:h-[26px] max-lg:w-[98px]"
             />
-          </div>
+          </a>
 
-          <nav className="flex items-center gap-xxl">
-            <a href="/create" className="text-body3-medium text-gray-900">
+          <nav className="flex items-center whitespace-nowrap">
+            <a
+              href="/create"
+              className="text-gray-900 px-3 py-2 text-[16px] leading-[1.4] font-medium shrink-0 max-lg:text-[clamp(14px,1.8vw,16px)]"
+            >
               문제 만들기
             </a>
-            <a href="/mock-exam" className="text-body3-medium text-gray-900">
+            <a
+              href="/mock-exam"
+              className="text-gray-900 px-3 py-2 text-[16px] leading-[1.4] font-medium shrink-0 ml-[50px] max-lg:ml-[clamp(8px,2.5vw,30px)]"
+            >
               실전 모의고사
             </a>
-            <a href="/my-quizzes" className="text-body3-medium text-gray-900">
+            <a
+              href="/my-quizzes"
+              className="text-gray-900 px-3 py-2 text-[16px] leading-[1.4] font-medium shrink-0 ml-[30px] max-lg:ml-[clamp(8px,2.5vw,30px)]"
+            >
               문제 모아보기
             </a>
             <a
               href="/wrong-quizzes"
-              className="text-body3-medium text-gray-900"
+              className="text-gray-900 px-3 py-2 text-[16px] leading-[1.4] font-medium shrink-0 ml-[24px] max-lg:ml-[clamp(8px,2.5vw,30px)]"
             >
               틀린문제 풀어보기
             </a>
             {isAuthenticated ? (
               <Button
                 variant="primary"
-                size="medium"
+                size="small"
                 onClick={handleLogoutClick}
+                className="ml-[17px] max-lg:ml-[clamp(6px,1.2vw,9px)] w-[70px] max-lg:w-[clamp(58px,7vw,70px)] whitespace-nowrap text-tint-regular max-lg:text-[clamp(12px,1.5vw,14px)] shrink-0"
               >
                 로그아웃
               </Button>
             ) : (
               <Button
                 variant="primary"
-                size="medium"
+                size="small"
                 onClick={handleLoginClick}
+                className="ml-[17px] max-lg:ml-[clamp(6px,1.2vw,9px)] w-[70px] max-lg:w-[clamp(58px,7vw,70px)] whitespace-nowrap text-tint-regular max-lg:text-[clamp(12px,1.5vw,14px)] shrink-0"
               >
                 로그인
               </Button>
@@ -79,10 +90,10 @@ const Header = ({ logoUrl = '/logo.svg', onLoginClick }: HeaderProps) => {
       </div>
 
       {/* Mobile Header */}
-      <div className="hidden max-md:flex items-center justify-between h-[50px] px-5 py-s">
-        <div className="flex items-center">
+      <div className="hidden max-md:flex items-center justify-between h-[46px] px-5 py-3">
+        <a href="/" className="flex items-center">
           <img src={logoUrl} alt="Quizly Logo" className="h-[22px] w-[84px]" />
-        </div>
+        </a>
 
         <button
           type="button"
@@ -98,6 +109,6 @@ const Header = ({ logoUrl = '/logo.svg', onLoginClick }: HeaderProps) => {
   );
 };
 
-Header.displayName = 'Header';
+Header.displayName = "Header";
 
 export default Header;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,7 @@ export default {
       spacing: spacing,
       screens: {
         md: '768px',
-        lg: '1024px',
+        lg: '1025px',
       },
       // Grid System - Figma Design System
       container: {
@@ -132,6 +132,11 @@ export default {
           fontSize: '14px',
           lineHeight: '1.4',
           fontWeight: '300',
+        },
+        '.text-caption': {
+          fontSize: '12px',
+          lineHeight: '1.4',
+          fontWeight: '400',
         },
         // Footer Text - Responsive
         '.text-footer': {


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: `Closes #17` (병합 시 자동으로 이슈 닫힘)

- 작업 사항
   - 로고 라우팅: 로고 클릭 시 메인 페이지(HomePage)로 이동
   - 헤더/푸터 사이즈 조정: Figma 디자인 기준으로 높이 및 로고 크기 수정
   - 반응형 대응: 태블릿 → 모바일 전환 시 헤더/푸터 줄 바꿈 방지를 위해 점진적 크기 감소 적용