### PR TITLE
feat(#33): 사용하지 않는 onClick함수 및 LoginModal 제거

### DIFF
--- a/src/app/pages/QuizDetailPage.tsx
+++ b/src/app/pages/QuizDetailPage.tsx
@@ -72,7 +72,7 @@ const QuizDetailPage = () => {
   // 회원인 경우
   return (
     <div className="min-h-screen bg-bg-home flex flex-col">
-      <Header logoUrl="/logo.svg" onLoginClick={handleOpenLoginModal} />
+      <Header logoUrl="/logo.svg" />
 
       {/* Main Content - Web/Tablet */}
       <main className="flex-1 flex flex-col items-center pt-20 pb-24 px-[60px] max-md:hidden">

--- a/src/app/pages/QuizListPage.tsx
+++ b/src/app/pages/QuizListPage.tsx
@@ -73,7 +73,7 @@ const QuizListPage = () => {
   // 회원인 경우
   return (
     <div className="min-h-screen bg-bg-home flex flex-col">
-      <Header logoUrl="/logo.svg" onLoginClick={handleOpenLoginModal} />
+      <Header logoUrl="/logo.svg" />
 
       {/* Main Content - Web/Tablet */}
       <main className="flex-1 flex flex-col items-center pt-20 pb-24 px-[60px] max-md:hidden">

--- a/src/app/pages/WrongQuizPage.tsx
+++ b/src/app/pages/WrongQuizPage.tsx
@@ -369,7 +369,7 @@ const WrongQuizPage = () => {
   if (!isAuthenticated) {
     return (
       <div className="min-h-screen bg-bg-home flex flex-col">
-        <Header logoUrl="/logo.svg" onLoginClick={handleOpenLoginModal} />
+        <Header logoUrl="/logo.svg" />
 
         {/* Main Content - Web/Tablet */}
         <main className="flex-1 flex flex-col items-center justify-center px-6 max-md:hidden">
@@ -477,7 +477,7 @@ const WrongQuizPage = () => {
   // 회원인 경우 - 틀린문제 목록 표시
   return (
     <div className="min-h-screen bg-bg-home flex flex-col">
-      <Header logoUrl="/logo.svg" onLoginClick={handleOpenLoginModal} />
+      <Header logoUrl="/logo.svg" />
 
       {/* Main Content - Web/Tablet */}
       <main className="flex-1 flex flex-col items-center pt-20 pb-24 px-[60px] max-md:hidden">

--- a/src/components/common/MemberOnlyPage.tsx
+++ b/src/components/common/MemberOnlyPage.tsx
@@ -10,13 +10,13 @@ type MemberOnlyPageProps = {
 const MemberOnlyPage = ({
   variant = 'full',
   isLoginModalOpen,
-  onOpenLoginModal,
+  onOpenLoginModal: _,
   onCloseLoginModal,
 }: MemberOnlyPageProps) => {
   if (variant === 'simple') {
     return (
       <div className="min-h-screen bg-bg-home flex flex-col">
-        <Header logoUrl="/logo.svg" onLoginClick={onOpenLoginModal} />
+        <Header logoUrl="/logo.svg" />
 
         <main className="flex-1 flex flex-col items-center justify-center px-6">
           <h1 className="text-header1-bold text-gray-900 text-center mb-4 max-md:text-header3-bold">
@@ -47,7 +47,7 @@ const MemberOnlyPage = ({
   // Full variant with characters
   return (
     <div className="min-h-screen bg-bg-home flex flex-col">
-      <Header logoUrl="/logo.svg" onLoginClick={onOpenLoginModal} />
+      <Header logoUrl="/logo.svg" />
 
       {/* Main Content - Web/Tablet */}
       <main className="flex-1 flex flex-col items-center justify-center px-6 max-md:hidden">

--- a/src/components/common/UnauthorizedPage.tsx
+++ b/src/components/common/UnauthorizedPage.tsx
@@ -16,7 +16,7 @@ const UnauthorizedPage = ({
   if (variant === 'simple') {
     return (
       <div className="min-h-screen bg-bg-home flex flex-col">
-        <Header logoUrl="/logo.svg" onLoginClick={onOpenLoginModal} />
+        <Header logoUrl="/logo.svg" />
 
         <main className="flex-1 flex flex-col items-center justify-center px-6">
           <h1 className="text-header1-bold text-gray-900 text-center mb-4 max-md:text-header3-bold">
@@ -45,7 +45,7 @@ const UnauthorizedPage = ({
   // Full variant with characters
   return (
     <div className="min-h-screen bg-bg-home flex flex-col">
-      <Header logoUrl="/logo.svg" onLoginClick={onOpenLoginModal} />
+      <Header logoUrl="/logo.svg" />
 
       {/* Main Content - Web/Tablet */}
       <main className="flex-1 flex flex-col items-center justify-center px-6 max-md:hidden">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,11 +5,10 @@ import { authUtils } from "@/lib/auth";
 
 type HeaderProps = {
   logoUrl?: string;
-  onLoginClick?: () => void; // deprecated: 이제 사용되지 않지만 하위 호환성을 위해 유지
   onMockExamClick?: () => void;
 };
 
-const Header = ({ logoUrl = "/logo.svg", onLoginClick, onMockExamClick }: HeaderProps) => {
+const Header = ({ logoUrl = "/logo.svg", onMockExamClick }: HeaderProps) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const navigate = useNavigate();
 


### PR DESCRIPTION
- 연관 이슈
  - 이 PR이 해결하는 이슈: Closes #33  (병합 시 자동으로 이슈 닫힘)
- 작업 내용
  - onLoginClick 및 onOpenLoginModal이 사용되지 않아 빌드과정에서 오류 발생 ->prop 제거 혹은 사용하지 않음 처리

- 테스트
  - 기능 정상 작동 및 빌드 성공
  - <img width="1797" height="927" alt="image" src="https://github.com/user-attachments/assets/8bb37e78-7e46-48d7-b0d2-fbbb09cd0f7f" />
