### PR TITLE
refactor(#35): footer 제거 및 refresh-token·PDF 경고 정리

### DIFF
--- a/src/api/quiz.ts
+++ b/src/api/quiz.ts
@@ -506,17 +506,13 @@ export const updateQuizzesTopic = async (
 export const createMockExam = async (
   request: CreateMockExamRequest
 ): Promise<MockExamResponse> => {
-  const token = authUtils.getAccessToken();
-  if (!token) {
-    throw new Error('로그인이 필요합니다.');
-  }
+  console.log('[회원] 모의고사 생성 요청:', {
+    url: `${API_BASE_URL}/mock/member`,
+    body: request,
+  });
 
-  const response = await fetch(`${API_BASE_URL}/mock/member`, {
+  const response = await authenticatedFetch(`${API_BASE_URL}/mock/member`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
     body: JSON.stringify(request),
   });
 
@@ -547,11 +543,6 @@ export const createMockExamByFile = async (
   file: File,
   mockExamTypeList: string[]
 ): Promise<MockExamResponse> => {
-  const token = authUtils.getAccessToken();
-  if (!token) {
-    throw new Error('로그인이 필요합니다.');
-  }
-
   const formData = new FormData();
   formData.append('file', file);
 
@@ -559,13 +550,13 @@ export const createMockExamByFile = async (
     .map((type) => `mockExamTypeList=${type}`)
     .join('&');
 
-  const response = await fetch(`${API_BASE_URL}/mock/member/ocr?${queryParams}`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-    body: formData,
-  });
+  const response = await authenticatedFetch(
+    `${API_BASE_URL}/mock/member/ocr?${queryParams}`,
+    {
+      method: 'POST',
+      body: formData,
+    }
+  );
 
   if (!response.ok) {
     const errorText = await response.text();

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -2,7 +2,6 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import type { ChangeEvent, KeyboardEvent } from 'react';
 import {
   Header,
-  Footer,
   Icon,
   QuizCreateModal,
   QuizGenerationLoadingPage,
@@ -612,11 +611,6 @@ const HomePage = () => {
             )}
           </div>
         </div>
-      </div>
-
-      {/* Footer - Web/Tablet Only */}
-      <div className="max-md:hidden">
-        <Footer />
       </div>
 
       {/* Quiz Create Modal */}

--- a/src/app/pages/QuizDetailPage.tsx
+++ b/src/app/pages/QuizDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { Header, Footer, LoginModal, UnauthorizedPage, QuizCard } from '@/components';
+import { Header, LoginModal, UnauthorizedPage, QuizCard } from '@/components';
 import { authUtils } from '@/lib/auth';
 import { getQuizGroups } from '@/api/quiz';
 import type { QuizHistoryDetail } from '@/types/quiz';
@@ -164,11 +164,6 @@ const QuizDetailPage = () => {
           </div>
         )}
       </main>
-
-      {/* Footer - Web/Tablet Only */}
-      <div className="max-md:hidden">
-        <Footer />
-      </div>
 
       {/* Login Modal */}
       <LoginModal isOpen={isLoginModalOpen} onClose={handleCloseLoginModal} />

--- a/src/app/pages/QuizListPage.tsx
+++ b/src/app/pages/QuizListPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Header, Footer, LoginModal, UnauthorizedPage, DateCard, Icon } from '@/components';
+import { Header, LoginModal, UnauthorizedPage, DateCard, Icon } from '@/components';
 import { authUtils } from '@/lib/auth';
 import { getQuizGroups } from '@/api/quiz';
 
@@ -171,11 +171,6 @@ const QuizListPage = () => {
           </div>
         )}
       </main>
-
-      {/* Footer - Web/Tablet Only */}
-      <div className="max-md:hidden">
-        <Footer />
-      </div>
 
       {/* Login Modal */}
       <LoginModal isOpen={isLoginModalOpen} onClose={handleCloseLoginModal} />

--- a/src/app/pages/QuizSolvePage.tsx
+++ b/src/app/pages/QuizSolvePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Header, Footer, Icon, QuizResultModal } from '@/components';
+import { Header, Icon, QuizResultModal } from '@/components';
 import ProgressBar from '@/components/common/ProgressBar';
 import type { QuizDetail, UserAnswer } from '@/types/quiz';
 import { submitAnswerMember } from '@/api/quiz';
@@ -635,11 +635,6 @@ const QuizSolvePage = ({
           </button>
         </div>
         
-      </div>
-
-      {/* Footer - Web/Tablet Only */}
-      <div className="max-md:hidden">
-        <Footer />
       </div>
 
       <QuizResultModal

--- a/src/app/pages/WrongQuizPage.tsx
+++ b/src/app/pages/WrongQuizPage.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import type { ChangeEvent } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { Header, Footer, LoginModal, Icon, Modal, Input } from '@/components';
+import { Header, LoginModal, Icon, Modal, Input } from '@/components';
 import { authUtils } from '@/lib/auth';
 import { getWrongQuizzes, updateQuizzesTopic } from '@/api/quiz';
 import type {
@@ -463,11 +463,6 @@ const WrongQuizPage = () => {
           </button>
         </main>
 
-        {/* Footer - Web/Tablet Only */}
-        <div className="max-md:hidden">
-          <Footer />
-        </div>
-
         {/* Login Modal */}
         <LoginModal isOpen={isLoginModalOpen} onClose={handleCloseLoginModal} />
       </div>
@@ -613,10 +608,6 @@ const WrongQuizPage = () => {
           {renderContent('grid grid-cols-2 gap-3 w-full')}
         </div>
       </main>
-
-      <div className="max-md:hidden">
-        <Footer />
-      </div>
 
       <LoginModal isOpen={isLoginModalOpen} onClose={handleCloseLoginModal} />
 

--- a/src/components/common/MemberOnlyPage.tsx
+++ b/src/components/common/MemberOnlyPage.tsx
@@ -1,4 +1,4 @@
-import { Header, Footer, LoginModal } from '@/components';
+import { Header, LoginModal } from '@/components';
 
 type MemberOnlyPageProps = {
   variant?: 'full' | 'simple';
@@ -34,10 +34,6 @@ const MemberOnlyPage = ({
             홈으로 돌아가기
           </button>
         </main>
-
-        <div className="max-md:hidden">
-          <Footer />
-        </div>
 
         <LoginModal isOpen={isLoginModalOpen} onClose={onCloseLoginModal} />
       </div>
@@ -142,11 +138,6 @@ const MemberOnlyPage = ({
           홈으로 돌아가기
         </button>
       </main>
-
-      {/* Footer - Web/Tablet Only */}
-      <div className="max-md:hidden">
-        <Footer />
-      </div>
 
       {/* Login Modal */}
       <LoginModal isOpen={isLoginModalOpen} onClose={onCloseLoginModal} />

--- a/src/components/common/UnauthorizedPage.tsx
+++ b/src/components/common/UnauthorizedPage.tsx
@@ -1,4 +1,4 @@
-import { Header, Footer, LoginModal } from '@/components';
+import { Header, LoginModal } from '@/components';
 
 type UnauthorizedPageProps = {
   variant?: 'full' | 'simple';
@@ -32,10 +32,6 @@ const UnauthorizedPage = ({
             로그인하기
           </button>
         </main>
-
-        <div className="max-md:hidden">
-          <Footer />
-        </div>
 
         <LoginModal isOpen={isLoginModalOpen} onClose={onCloseLoginModal} />
       </div>
@@ -138,11 +134,6 @@ const UnauthorizedPage = ({
           지금 가입하기
         </button>
       </main>
-
-      {/* Footer - Web/Tablet Only */}
-      <div className="max-md:hidden">
-        <Footer />
-      </div>
 
       {/* Login Modal */}
       <LoginModal isOpen={isLoginModalOpen} onClose={onCloseLoginModal} />

--- a/src/components/modal/MockExamSettingModal.tsx
+++ b/src/components/modal/MockExamSettingModal.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import type { ChangeEvent } from 'react';
 import Tooltip from '@/components/common/Tooltip';
 import Icon from '@/components/common/Icon';
-import { validatePdfPageCount, validateFileType } from '@/lib/pdfUtils';
+import { validateFileType } from '@/lib/pdfUtils';
 
 type MockExamType = 'TRUE_FALSE' | 'FIND_CORRECT' | 'SHORT_ANSWER' | 'ESSAY';
 type MockExamCharacteristic = 'FIND_CORRECT' | 'FIND_INCORRECT' | 'FIND_MATCH';
@@ -79,7 +79,7 @@ const MockExamSettingModal = ({ isOpen, onClose, onSubmit }: MockExamSettingModa
     }
   }, []);
 
-  const handleFileUpload = useCallback(async (e: ChangeEvent<HTMLInputElement>) => {
+  const handleFileUpload = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const uploadedFile = e.target.files?.[0];
     if (!uploadedFile) return;
 
@@ -91,19 +91,6 @@ const MockExamSettingModal = ({ isOpen, onClose, onSubmit }: MockExamSettingModa
       alert(typeValidation.error);
       e.target.value = '';
       return;
-    }
-
-    // PDF 파일인 경우 페이지 수 체크
-    if (uploadedFile.type === 'application/pdf') {
-      const pdfValidation = await validatePdfPageCount(uploadedFile, 10);
-
-      if (!pdfValidation.isValid) {
-        alert(pdfValidation.error);
-        e.target.value = '';
-        return;
-      }
-
-      console.log('PDF 페이지 수:', pdfValidation.pageCount);
     }
 
     // JPG/PNG 파일인 경우 안내 메시지 (이미 한 장만 선택 가능)


### PR DESCRIPTION
연관 이슈

 - 이 PR이 해결하는 이슈: Closes #35 (병합 시 자동으로 이슈 닫힘)


작업 사항
 - 추후 마이페이지에만 footer를 두기로 논의 ->현재 적용된 모든 페이지의 footer를 제거 
 - 모의고사 생성 페이지만 refresh token이 적용되지 않는 문제 authenticatedFetch 사용으로 수정
 - 모의고사 pdf 수량 제한 문제 해결 -> 해당 제한과 에러 문구 삭제

테스트
<img width="1718" height="1272" alt="image" src="https://github.com/user-attachments/assets/e08dffe2-0318-4773-b6f8-f8ea68f2ce6a" />
<img width="1723" height="1255" alt="image" src="https://github.com/user-attachments/assets/0bded771-3d32-4582-ab52-99c914dc553c" />
