### PR TITLE
feat(#50): 틀린 문제 풀기 전용 채점 API 적용

### DIFF
--- a/src/api/quiz.ts
+++ b/src/api/quiz.ts
@@ -387,6 +387,48 @@ export const submitAnswerMember = async (
 };
 
 /**
+ * 답안 제출 - 틀린 문제 재도전 (회원)
+ * @param quizId - 문제 ID
+ * @param userAnswer - 사용자가 선택한 답안
+ * @param solveTime - 문제 풀이 시간 (초)
+ */
+export const submitAnswerRetry = async (
+  quizId: number,
+  userAnswer: string,
+  solveTime: number
+): Promise<SubmitAnswerResponse> => {
+  console.log('[회원] 틀린 문제 재도전 답안 제출 요청:', {
+    url: `${API_BASE_URL}/quizzes/${quizId}/answer/retry`,
+    body: { userAnswer, solveTime },
+  });
+
+  const response = await authenticatedFetch(
+    `${API_BASE_URL}/quizzes/${quizId}/answer/retry`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ userAnswer, solveTime }),
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+
+    let errorData;
+    try {
+      errorData = JSON.parse(errorText);
+    } catch {
+      errorData = { message: errorText };
+    }
+
+    throw new Error(
+      errorData.message || `답안 제출 실패: ${response.status} ${response.statusText}`
+    );
+  }
+
+  return response.json();
+};
+
+/**
  * 문제 모아보기 조회 (회원)
  * @param groupType - 그룹화 기준 (예: 'date')
  */

--- a/src/app/pages/QuizSolvePage.tsx
+++ b/src/app/pages/QuizSolvePage.tsx
@@ -3,11 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import { Header, Icon, QuizResultModal } from '@/components';
 import ProgressBar from '@/components/common/ProgressBar';
 import type { QuizDetail, UserAnswer } from '@/types/quiz';
-import { submitAnswerMember } from '@/api/quiz';
+import { submitAnswerMember, submitAnswerRetry } from '@/api/quiz';
 import { authUtils } from '@/lib/auth';
 
 type QuizSolvePageProps = {
   quizDetailList: QuizDetail[];
+  isRetryMode?: boolean;
   onComplete?: (answers: UserAnswer[]) => void;
   onExit?: () => void;
   onViewAll?: (answers: UserAnswer[]) => void;
@@ -15,6 +16,7 @@ type QuizSolvePageProps = {
 
 const QuizSolvePage = ({
   quizDetailList,
+  isRetryMode = false,
   onComplete,
   onExit,
   onViewAll,
@@ -112,11 +114,20 @@ const QuizSolvePage = ({
       if (isAuthenticated) {
         setIsSubmitting(true);
         try {
-          await submitAnswerMember(
-            currentQuiz.quizId,
-            selectedAnswer,
-            solveTimeSeconds
-          );
+          // 틀린 문제 재도전 모드면 retry API 사용, 아니면 기본 API 사용
+          if (isRetryMode) {
+            await submitAnswerRetry(
+              currentQuiz.quizId,
+              selectedAnswer,
+              solveTimeSeconds
+            );
+          } else {
+            await submitAnswerMember(
+              currentQuiz.quizId,
+              selectedAnswer,
+              solveTimeSeconds
+            );
+          }
         } catch (error) {
           // 에러가 발생해도 UI 흐름은 유지 (사용자 경험 보호)
           if (import.meta.env.DEV) {

--- a/src/app/pages/WrongQuizSolvePage.tsx
+++ b/src/app/pages/WrongQuizSolvePage.tsx
@@ -70,6 +70,7 @@ const WrongQuizSolvePage = () => {
   return (
     <QuizSolvePage
       quizDetailList={quizDetailList}
+      isRetryMode={true}
       onComplete={handleComplete}
       onExit={handleExit}
       onViewAll={handleViewAll}


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: Closes #50 (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - 틀린 문제 풀어보기에서 사용하는 채점 API를 `POST /quizzes/{quizId}/answer/retry` 변경 

- 테스트
    - 대시보드 영향도 검증
        -> 틀린 문제 다시 풀기 기록이 대시보드 요약 통계에 반영되지 않는지 테스트 완료 
