### PR TITLE
feat(#60): Vercal SPA 라우팅 설정, 타입 스크립트 미사용 변수 체크 옵션 제거

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,8 +18,8 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: Closes #60 (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - Vercel SPA 라우팅 설정 추가 (vercel.json)                                                                                         
    - TypeScript 미사용 변수 체크 옵션 비활성화  

- 테스트
    - 배포 완료 후 실사용 테스트 완료 (https://quizly.co.kr/) 