### PR TITLE
feat(#64): 문제 풀이 중 이탈 방지 모달 추가

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -120,4 +120,62 @@ export const QuizResultModal = ({
 
 QuizResultModal.displayName = 'QuizResultModal';
 
+type QuizExitConfirmModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirmExit: () => void;
+};
+
+export const QuizExitConfirmModal = ({
+  isOpen,
+  onClose,
+  onConfirmExit,
+}: QuizExitConfirmModalProps) => {
+  return (
+    <MuiModal
+      open={isOpen}
+      onClose={onClose}
+      className="flex items-center justify-center"
+    >
+      <div className="bg-white rounded-[24px] px-6 py-[30px] w-[380px] mx-m outline-none max-md:w-[300px]">
+        {/* Content */}
+        <div className="flex flex-col items-center gap-6">
+          {/* Text Content */}
+          <div className="flex flex-col items-center gap-2">
+            <p className="text-tint-regular text-primary text-center">
+              아직 문제를 다 풀지 못했어요!
+            </p>
+            <div className="flex flex-col items-center gap-3">
+              <h2 className="text-[20px] font-bold text-gray-900 leading-[1.4] text-center">
+                멈추고 나가시겠어요?
+              </h2>
+              <p className="text-body3-regular text-gray-600 text-center">
+                풀이가 종료되면 생성된 문제는<br />전부 오답처리 됩니다.
+              </p>
+            </div>
+          </div>
+
+          {/* Buttons */}
+          <div className="flex gap-3 justify-center">
+            <button
+              onClick={onClose}
+              className="bg-gray-200 text-gray-900 text-tint-regular px-2 py-[10px] rounded-[4px] w-[96px] hover:bg-gray-300 transition-colors"
+            >
+              취소
+            </button>
+            <button
+              onClick={onConfirmExit}
+              className="bg-primary text-white text-tint-regular px-2 py-[10px] rounded-[4px] w-[96px] hover:bg-primary/90 transition-colors"
+            >
+              나가기
+            </button>
+          </div>
+        </div>
+      </div>
+    </MuiModal>
+  );
+};
+
+QuizExitConfirmModal.displayName = 'QuizExitConfirmModal';
+
 export default Modal;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,4 +1,4 @@
-export { default as Modal, QuizResultModal } from './Modal';
+export { default as Modal, QuizResultModal, QuizExitConfirmModal } from './Modal';
 export { default as Input } from './Input';
 export { default as Card } from './Card';
 export { default as Icon } from './Icon';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,7 +2,7 @@
 export { Header, Footer } from "./layout";
 
 // Common Components
-export { Modal, QuizResultModal, Input, Card, Icon, Button } from "./common";
+export { Modal, QuizResultModal, QuizExitConfirmModal, Input, Card, Icon, Button } from "./common";
 export { default as QuizCreateModal } from "./common/QuizCreateModal";
 export { default as ProgressBar } from "./common/ProgressBar";
 export { default as DateCard } from "./common/DateCard";


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: Closes #64 (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - 이탈 방지 로직 구현
        - 데스크탑/태블릿 : 헤더의 모든 클릭 가능한 요소 감지
        - 모바일 : 나가기 버튼
                                                                                                    
- 테스트
   - 데스크탑
       <img width=85% alt="스크린샷 2026-01-26 오후 4 41 52" src="https://github.com/user-attachments/assets/fa40de6f-0471-470e-8bcc-03fe4e029449" />
   - 모바일
       <img width=30% alt="스크린샷 2026-01-26 오후 4 42 03" src="https://github.com/user-attachments/assets/a5995b97-5ba2-4aef-abe9-ff8cef02b54a" />
