### PR TITLE
feat(#67): 모바일 메뉴 프로필 이미지 클릭 동작 및 스타일 개선

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -253,8 +253,15 @@ const Header = ({ logoUrl = "/logo.svg", onMockExamClick }: HeaderProps) => {
                               </button>
                             </div>
                             {/* 프로필 이미지 */}
-                            <div className="relative w-[60px] h-[60px] flex items-center justify-center shrink-0">
-                              <div className="w-[60px] h-[60px] rounded-full bg-[#efefef] overflow-hidden">
+                            <button
+                              onClick={handleProfileClick}
+                              className="relative w-[60px] h-[60px] flex items-center justify-center shrink-0 cursor-pointer"
+                              aria-label="대시보드로 이동"
+                            >
+                              {/* 외곽 원: 60x60, stroke primary (1.5px) */}
+                              <div className="absolute inset-0 rounded-full border-[1.5px] border-primary"></div>
+                              {/* 내부 원: 57x57 (60 - 3px border), fill #efefef */}
+                              <div className="w-[57px] h-[57px] rounded-full bg-[#efefef] overflow-hidden">
                                 <img
                                   src={userInfo.profileImageUrl || '/icon/default.svg'}
                                   alt="프로필"
@@ -267,7 +274,7 @@ const Header = ({ logoUrl = "/logo.svg", onMockExamClick }: HeaderProps) => {
                                   }}
                                 />
                               </div>
-                            </div>
+                            </button>
                           </div>
                           
                           {/* 배너 - 로그아웃 버튼 아래 */}


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: Closes #67 (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - 프로필 이미지 클릭 시 대시보드(/analytics) 페이지로 이동
    - 프로필 이미지에 초록색 stroke 추가 (피그마 반영)
                                                                                                    
- 테스트
   - 모바일
       <img width=30% alt="스크린샷 2026-01-26 오후 5 25 44" src="https://github.com/user-attachments/assets/7d721e2e-6ca9-44b3-9b6d-7bda0febb969" />