### PR TITLE
refactor(#79): 온보딩, 계정 관리, 로그인 페이지, 대시보드 UI 수정

### DIFF
--- a/src/app/pages/AnalyticsPage.tsx
+++ b/src/app/pages/AnalyticsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Header, Footer, Button, Input } from '@/components';
+import { Header, Footer, Button } from '@/components';
 import { authUtils } from '@/lib/auth';
 import {
   getUserInfo,
@@ -200,14 +200,14 @@ const AnalyticsPage = () => {
     <div className="min-h-screen bg-bg-home flex flex-col">
       <Header />
       
-      <main className="flex-1 flex flex-col items-center pt-20 pb-24 px-[60px] max-lg:px-15 max-md:px-margin-mobile max-md:pt-6">
-        <div className="w-full max-w-[1024px]">
+      <main className="flex-1 flex flex-col items-center pt-20 pb-24 px-[60px] max-lg:px-15 max-md:px-5 max-md:pt-5">
+        <div className="w-full max-w-[1024px] max-md:max-w-full">
           {/* 탭 헤더 */}
-          <div className="mb-[30px]">
-            <div className="flex items-center gap-6 mb-[6px]">
+          <div className="mb-[30px] max-md:mb-[31px]">
+            <div className="flex items-center gap-6 max-md:gap-4 mb-[6px] max-md:mb-5">
               <button
                 onClick={() => setActiveTab('analytics')}
-                className={`text-[32px] font-bold leading-[44.8px] ${
+                className={`text-[32px] max-md:text-[24px] font-bold leading-[44.8px] max-md:leading-[33.6px] ${
                   activeTab === 'analytics' ? 'text-gray-900' : 'text-gray-300'
                 }`}
               >
@@ -215,14 +215,14 @@ const AnalyticsPage = () => {
               </button>
               <button
                 onClick={() => setActiveTab('account')}
-                className={`text-[32px] font-bold leading-[44.8px] ${
+                className={`text-[32px] max-md:text-[24px] font-bold leading-[44.8px] max-md:leading-[33.6px] ${
                   activeTab === 'account' ? 'text-gray-900' : 'text-gray-300'
                 }`}
               >
                 계정관리
               </button>
             </div>
-            <p className="text-[20px] leading-[28px] text-gray-600">
+            <p className="text-[20px] max-md:text-[16px] leading-[28px] max-md:leading-[22.4px] text-gray-600">
               학습 현황을 확인하고 계정을 관리하세요
             </p>
           </div>
@@ -296,8 +296,8 @@ const AnalyticsPage = () => {
         )}
 
         {activeTab === 'account' && (
-          <div className="bg-white rounded-2xl p-8 border border-gray-300">
-            <h2 className="text-[20px] font-medium leading-[28px] mb-8 text-gray-900">
+          <div className="bg-white rounded-2xl max-md:rounded-[16px] p-8 max-md:p-5 border border-gray-300 max-md:border-[#dedede]">
+            <h2 className="text-[20px] font-medium leading-[28px] mb-[30px] max-md:mb-[20px] text-gray-900">
               프로필 정보
             </h2>
 
@@ -312,9 +312,9 @@ const AnalyticsPage = () => {
             ) : (
               <>
                 {/* 프로필 이미지 */}
-                <div className="flex items-center justify-center gap-6 mb-8">
+                <div className="flex items-center justify-center gap-6 mb-[30px] max-md:mb-[20px]">
                   <div className="relative">
-                    <div className="w-[110px] h-[110px] rounded-full border-2 border-primary overflow-hidden">
+                    <div className="w-[110px] h-[110px] max-md:w-[80px] max-md:h-[80px] rounded-full border-2 border-primary overflow-hidden">
                       {previewImageUrl ? (
                         // 미리보기 이미지 표시
                         <img
@@ -339,13 +339,13 @@ const AnalyticsPage = () => {
                     <button
                       onClick={handleProfileImageClick}
                       disabled={isSaving}
-                      className="absolute bottom-0 right-0 w-[26px] h-[26px] rounded-full bg-primary flex items-center justify-center hover:bg-primary-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="absolute bottom-0 right-0 w-[26px] h-[26px] max-md:w-[22px] max-md:h-[22px] rounded-full bg-primary flex items-center justify-center hover:bg-primary-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                       aria-label="프로필 이미지 변경"
                     >
                       <img
                         src="/icon/icn_write.svg"
                         alt="프로필 이미지 변경"
-                        className="w-4 h-4"
+                        className="w-4 h-4 max-md:w-3 max-md:h-3"
                       />
                     </button>
                     <input
@@ -359,39 +359,51 @@ const AnalyticsPage = () => {
                 </div>
 
             {/* 닉네임 입력 */}
-            <div className="mb-6 flex flex-col items-center">
-              <div className="max-w-[350px] w-full">
-                <Input
-                  label="닉네임"
-                  value={nickname}
-                  onChange={(e) => {
-                    const newValue = e.target.value;
-                    // 6자까지만 입력 가능
-                    if (newValue.length <= 6) {
-                      setNickname(newValue);
-                      setSaveError(null);
-                    }
-                  }}
-                  maxLength={6}
-                  className="w-full"
-                  error={saveError || undefined}
-                />
-                <p className="mt-2 text-[14px] text-gray-600 text-left">
-                  닉네임은 6자까지만 가능합니다.
-                </p>
+            <div className="mb-[20px] max-md:mb-[20px] flex flex-col items-center">
+              <div className="flex flex-col items-start w-[350px] max-md:w-[295px]">
+                <label className="text-[16px] font-medium text-gray-600 mb-1">
+                  닉네임
+                </label>
+                <div className="border-b border-[#dedede] flex items-center w-full py-2">
+                  <input
+                    type="text"
+                    value={nickname}
+                    onChange={(e) => {
+                      const newValue = e.target.value;
+                      // 6자까지만 입력 가능
+                      if (newValue.length <= 6) {
+                        setNickname(newValue);
+                        setSaveError(null);
+                      }
+                    }}
+                    maxLength={6}
+                    disabled={isSaving}
+                    className="flex-1 text-[16px] text-gray-900 outline-none bg-transparent disabled:text-gray-500"
+                  />
+                </div>
+                {saveError && (
+                  <p className="mt-1 text-[14px] text-red-500">
+                    {saveError}
+                  </p>
+                )}
               </div>
             </div>
 
             {/* 이메일 입력 (비활성화) */}
-            <div className="mb-8 flex flex-col items-center">
-              <div className="max-w-[350px] w-full">
-                <Input
-                  label="이메일"
-                  value={email}
-                  disabled
-                  className="w-full"
-                />
-                <p className="mt-2 text-[14px] text-red-500 text-left">
+            <div className="mb-[30px] max-md:mb-[20px] flex flex-col items-center">
+              <div className="flex flex-col items-start w-[350px] max-md:w-[295px]">
+                <label className="text-[16px] font-medium text-gray-600 mb-1">
+                  이메일
+                </label>
+                <div className="border-b border-[#dedede] flex items-center w-full py-2">
+                  <input
+                    type="text"
+                    value={email}
+                    disabled
+                    className="flex-1 text-[16px] text-gray-900 outline-none bg-transparent disabled:text-gray-500"
+                  />
+                </div>
+                <p className="mt-1 text-[14px] text-red-500">
                   이메일은 변경할 수 없습니다.
                 </p>
               </div>

--- a/src/app/pages/LoginPage.tsx
+++ b/src/app/pages/LoginPage.tsx
@@ -39,8 +39,8 @@ const LoginPage = ({
       <Header logoUrl="/logo.svg" />
 
       {/* Main Content */}
-      <main className="flex-1 flex justify-center px-6">
-        <div className="flex flex-col items-center max-md:pt-[100px] md:pt-[200px]">
+      <main className="flex-1 flex items-center justify-center px-6 max-lg:items-start max-lg:pt-[80px]">
+        <div className="flex flex-col items-center">
           {/* Login Box */}
           <div className="relative bg-white rounded-[24px] border border-[#dedede] w-[500px] max-md:w-full max-md:mx-4 px-[60px] max-md:px-[20px] py-[72px] max-md:py-[40px] flex flex-col items-center">
           {/* Logo */}

--- a/src/app/pages/OnboardingPage.tsx
+++ b/src/app/pages/OnboardingPage.tsx
@@ -118,10 +118,10 @@ const OnboardingPage = () => {
     <div className="h-screen bg-bg-home flex flex-col overflow-hidden max-md:overflow-hidden">
       <Header logoUrl="/logo.svg" />
 
-      <main className="flex-1 flex justify-center px-6 overflow-hidden max-md:overflow-hidden max-md:relative">
-        <div className="flex flex-col items-center max-md:pt-[20px] md:pt-[80px] max-md:pb-[106px] max-md:h-full w-full max-w-[700px]">
+      <main className="flex-1 flex justify-center px-6 overflow-y-auto max-md:overflow-hidden max-md:relative">
+        <div className="flex flex-col items-center max-md:pt-[20px] md:pt-[60px] max-md:pb-[106px] max-md:h-full w-full max-w-[700px] md:pb-8">
           {/* Progress Indicator */}
-          <div className="flex items-center justify-center mb-[40px] max-md:mb-[20px] max-md:shrink-0">
+          <div className="flex items-center justify-center mb-[47px] max-md:mb-[20px] max-md:shrink-0">
             {/* Step 1 */}
             <div className="flex flex-col items-center gap-4 max-md:gap-2" style={{ width: '91px', height: '80px' }}>
               <div className="relative flex items-center justify-center w-[46px] h-[46px] max-md:w-[32px] max-md:h-[32px]">
@@ -138,7 +138,7 @@ const OnboardingPage = () => {
                 )}
               </div>
               <span
-                className={`text-[16px] max-md:text-[14px] font-medium max-md:font-normal ${
+                className={`text-[16px] max-md:text-[14px] font-medium max-md:font-normal whitespace-nowrap ${
                   step >= 1 ? 'text-primary' : 'text-[#b7b7b7]'
                 }`}
               >
@@ -165,7 +165,7 @@ const OnboardingPage = () => {
                 )}
               </div>
               <span
-                className={`text-[16px] max-md:text-[14px] font-medium max-md:font-normal ${
+                className={`text-[16px] max-md:text-[14px] font-medium max-md:font-normal whitespace-nowrap ${
                   step === 2 || selectedGoals.length > 0 || selectedUserType ? 'text-primary' : 'text-[#b7b7b7]'
                 }`}
               >
@@ -175,64 +175,65 @@ const OnboardingPage = () => {
           </div>
 
           {/* Content Box */}
-          <div className={`bg-white rounded-[24px] border border-[#dedede] w-full max-w-[700px] max-md:max-w-[335px] max-md:w-[335px] relative flex flex-col items-center max-md:shrink-0 ${step === 1 ? 'max-md:h-[364px] md:h-[606px]' : 'max-md:h-[492px] md:h-[694px]'}`}>
-          {/* Step 1: User Type Selection */}
-          {step === 1 && (
-            <>
-              <div 
-                className="flex items-center justify-center w-full max-md:mt-[30px] md:mt-[60px] px-4"
-              >
-                <h1 
-                  className="onboarding-title max-md:font-semibold text-gray-900 text-center max-md:whitespace-nowrap"
-                  style={{ lineHeight: '28px' }}
+          <div className={`bg-white rounded-[24px] border border-[#dedede] w-full max-w-[700px] max-md:max-w-[335px] max-md:w-[335px] max-md:mx-auto relative flex flex-col items-center max-md:shrink-0 ${step === 1 ? 'max-md:h-[364px]' : 'max-md:h-[492px]'}`}>
+            {/* Step 1: User Type Selection */}
+            {step === 1 && (
+              <>
+                <div
+                  className="flex items-center justify-center w-full max-md:mt-[30px] md:mt-[60px] px-4"
                 >
-                  퀴즐리에 오신 것을 환영합니다!👋🏻
-                </h1>
-              </div>
-              <p 
-                className="text-body3-regular text-gray-600 text-center max-md:mt-[4px] md:mt-[6px] max-md:mb-[52px] md:mb-[40px]"
-                style={{ lineHeight: '22.4px' }}
-              >
-                어떤 분이 이용하시나요?
-              </p>
+                  <h1
+                    className="onboarding-title max-md:font-semibold text-gray-900 text-center max-md:whitespace-nowrap"
+                    style={{ lineHeight: '28px' }}
+                  >
+                    퀴즐리에 오신 것을 환영합니다!👋🏻
+                  </h1>
+                </div>
+                <p
+                  className="text-body3-regular text-gray-600 text-center max-md:mt-[4px] md:mt-[6px] max-md:mb-[30px] md:mb-[40px]"
+                  style={{ lineHeight: '22.4px' }}
+                >
+                  어떤 분이 이용하시나요?
+                </p>
 
-              <div className="flex flex-wrap justify-center gap-4 max-md:gap-2 w-full max-w-[584px] max-md:mb-0 max-md:px-4 md:mb-12">
-                {userTypes.map((type) => (
+                <div className="grid grid-cols-2 gap-3 max-md:gap-2 w-full max-w-[580px] max-md:mb-0 max-md:px-4 max-md:justify-center">
+                  {userTypes.map((type) => (
+                    <button
+                      key={type.id}
+                      onClick={() => handleUserTypeSelect(type.id)}
+                      className={`flex flex-col items-center justify-center gap-4 max-md:gap-2 rounded-[16px] border transition-colors max-md:w-[132px] max-md:h-[104px] md:w-[284px] md:h-[148px] ${
+                        selectedUserType === type.id
+                          ? 'bg-white border-primary'
+                          : 'bg-white border-[#ededed] hover:border-primary/50'
+                      }`}
+                    >
+                      <img
+                        src={type.character}
+                        alt={type.label}
+                        className={type.id === 'university' ? 'w-[57px] h-[52px] max-md:w-[40px] max-md:h-[36px]' : 'w-[52px] h-[52px] max-md:w-[36px] max-md:h-[36px]'}
+                      />
+                      <span className="text-body2-medium max-md:text-[16px] text-gray-900">
+                        {type.label}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+
+                <div className="w-full max-w-[580px] flex justify-end mt-5 mb-[60px] max-md:hidden">
                   <button
-                    key={type.id}
-                    onClick={() => handleUserTypeSelect(type.id)}
-                    className={`flex flex-col items-center justify-center gap-4 max-md:gap-2 rounded-[16px] border transition-colors max-md:w-[132px] max-md:h-[104px] md:w-[284px] md:h-[148px] max-md:flex-shrink-0 ${
-                      selectedUserType === type.id
-                        ? 'bg-white border-primary'
-                        : 'bg-white border-[#ededed] hover:border-primary/50'
+                    onClick={handleNext}
+                    disabled={isStep1NextDisabled}
+                    className={`px-4 py-3 rounded-[6px] text-body3-regular text-white transition-colors ${
+                      isStep1NextDisabled
+                        ? 'bg-[#b7b7b7] cursor-not-allowed'
+                        : 'bg-primary hover:bg-primary-dark'
                     }`}
                   >
-                    <img
-                      src={type.character}
-                      alt={type.label}
-                      className={type.id === 'university' ? 'w-[57px] h-[52px] max-md:w-[40px] max-md:h-[36px]' : 'w-[52px] h-[52px] max-md:w-[36px] max-md:h-[36px]'}
-                    />
-                    <span className="text-body2-medium max-md:text-[16px] text-gray-900">
-                      {type.label}
-                    </span>
+                    다음 질문
                   </button>
-                ))}
-              </div>
-
-              <button
-                onClick={handleNext}
-                disabled={isStep1NextDisabled}
-                className={`w-full max-w-[584px] max-md:hidden h-[46px] rounded-[6px] text-body3-regular text-white transition-colors ${
-                  isStep1NextDisabled
-                    ? 'bg-[#b7b7b7] cursor-not-allowed'
-                    : 'bg-primary hover:bg-primary-dark'
-                }`}
-                style={{ marginBottom: '48px' }}
-              >
-                다음 질문
-              </button>
-            </>
-          )}
+                </div>
+              </>
+            )}
 
           {/* Step 2: Learning Goals Selection */}
           {step === 2 && (
@@ -247,21 +248,21 @@ const OnboardingPage = () => {
                   학습 목표를 선택해주세요
                 </h1>
               </div>
-              <p 
-                className="text-body3-regular text-gray-600 text-center max-md:mt-[4px] md:mt-[6px] max-md:mb-[52px] md:mb-[40px]"
+              <p
+                className="text-body3-regular text-gray-600 text-center max-md:mt-[4px] md:mt-[6px] max-md:mb-[30px] md:mb-[40px]"
                 style={{ lineHeight: '22.4px' }}
               >
                 중복 선택이 가능합니다.
               </p>
 
-              <div className="flex flex-col gap-2 max-md:mb-0 max-md:px-[30px] w-full max-w-[580px] md:mb-12">
+              <div className="flex flex-col gap-2 max-md:mb-0 w-full max-w-[580px] max-md:max-w-[275px] max-md:mx-auto">
                 {learningGoals.map((goal) => {
                   const isSelected = selectedGoals.includes(goal.id);
                   return (
                     <button
                       key={goal.id}
                       onClick={() => handleGoalToggle(goal.id)}
-                      className={`flex items-center gap-4 px-4 py-4 rounded-[12px] border text-left transition-colors w-full max-md:h-[48px] md:h-[56px] ${
+                      className={`flex items-center gap-3 p-3 rounded-[12px] border text-left transition-colors w-full max-md:h-[52px] md:h-[56px] ${
                         isSelected
                           ? 'bg-[#fcfcfc] border-primary'
                           : 'bg-[#fcfcfc] border-[#ededed] hover:border-primary/50'
@@ -269,7 +270,8 @@ const OnboardingPage = () => {
                     >
                       <Icon
                         name={isSelected ? 'icn_check_fill_in' : 'icn_check_fill'}
-                        size={24}
+                        size={28}
+                        className="shrink-0"
                       />
                       <span className="text-body3-regular text-gray-900">
                         {goal.label}
@@ -279,24 +281,26 @@ const OnboardingPage = () => {
                 })}
               </div>
 
-              <div className="flex gap-4 max-md:hidden w-full max-w-[580px]">
-                <button
-                  onClick={handlePrev}
-                  className="flex-1 h-[46px] rounded-[6px] bg-white border border-[#d9d9d9] text-body3-regular text-gray-600 hover:bg-gray-50 transition-colors"
-                >
-                  이전 질문
-                </button>
-                <button
-                  onClick={handleComplete}
-                  disabled={isStep2NextDisabled}
-                  className={`flex-1 h-[46px] rounded-[6px] text-body3-regular text-white transition-colors ${
-                    isStep2NextDisabled
-                      ? 'bg-[#b7b7b7] cursor-not-allowed'
-                      : 'bg-primary hover:bg-primary-dark'
-                  }`}
-                >
-                  시작하기
-                </button>
+              <div className="w-full max-w-[580px] flex justify-end mt-5 mb-[60px] max-md:hidden">
+                <div className="flex gap-3">
+                  <button
+                    onClick={handlePrev}
+                    className="px-4 py-3 rounded-[6px] bg-white border border-[#d9d9d9] text-body3-regular text-gray-600 hover:bg-gray-50 transition-colors"
+                  >
+                    이전 질문
+                  </button>
+                  <button
+                    onClick={handleComplete}
+                    disabled={isStep2NextDisabled}
+                    className={`px-4 py-3 rounded-[6px] text-body3-regular text-white transition-colors ${
+                      isStep2NextDisabled
+                        ? 'bg-[#b7b7b7] cursor-not-allowed'
+                        : 'bg-primary hover:bg-primary-dark'
+                    }`}
+                  >
+                    시작하기
+                  </button>
+                </div>
               </div>
             </>
           )}

--- a/src/components/dashboard/learning-stats.tsx
+++ b/src/components/dashboard/learning-stats.tsx
@@ -55,7 +55,7 @@ export default function LearningStats({ dailyData, quizTypeData, hourlyData }: P
       if (peakHour) {
         const startHour = String(peakHour.startHour).padStart(2, '0');
         const endHour = String(peakHour.startHour + 3).padStart(2, '0');
-        peakTimeRange = `${startHour}:00 ~ ${endHour}:00`;
+        peakTimeRange = `${startHour}시~${endHour}시`;
       }
     }
 


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: close #79  (병합 시 자동으로 이슈 닫힘)

- 작업 사항                             
    - 확대/축소 비율 100%에서 짤리는 부분 수정
        - 온보딩 (버튼 위치 및 전체적인 컴포넌트 크기 수정)
        - 계정 관리 (이메일, 닉네임 입력 필드 디자인 수장)
        - 로그인 페이지 (헤더와 간격 수정)
    - 대시보드 (평균 학습 시간대의 시간 표시 방식 변경)
                                 
- 테스트
    - 온보딩 페이지
        <img width="80%" alt="스크린샷 2026-02-02 오후 2 20 00" src="https://github.com/user-attachments/assets/1bc8a2d4-f494-4141-8abe-dba5e4418c09" />

    - 계정 관리 페이지
        <img width="80%" alt="스크린샷 2026-02-02 오후 2 25 56" src="https://github.com/user-attachments/assets/48a27474-296a-4f2f-ad2a-888395a908eb" />
        <img width="30%" alt="스크린샷 2026-02-02 오후 3 47 56" src="https://github.com/user-attachments/assets/d0644d65-2349-4244-976f-c09574410bee" />

    - 로그인 페이지
        <img width="80%" alt="스크린샷 2026-02-02 오후 3 49 59" src="https://github.com/user-attachments/assets/917865b2-5295-4008-a9e9-7295e1f85ba0" />

    - 대시보드
    
        <img width="80%" alt="스크린샷 2026-02-02 오후 3 50 25" src="https://github.com/user-attachments/assets/de76678d-377b-4cc8-bc97-a0daa89ca285" />
