### PR TITLE
refactor(#87): 온보딩 데이터 및 문제 모아보기 OX표기 수정

### DIFF
--- a/src/app/pages/OnboardingPage.tsx
+++ b/src/app/pages/OnboardingPage.tsx
@@ -24,7 +24,7 @@ const OnboardingPage = () => {
 
   const userTypes = [
     { id: 'highschool' as const, label: '고등학생', character: '/characters/character1.png' },
-    { id: 'university' as const, label: '대학생', character: '/characters/character2.png' },
+    { id: 'university' as const, label: '대학(원)생', character: '/characters/character2.png' },
     { id: 'jobseeker' as const, label: '취준생', character: '/characters/character3.png' },
     { id: 'general' as const, label: '일반 학습자', character: '/characters/character4.png' },
   ];

--- a/src/components/common/QuizCard.tsx
+++ b/src/components/common/QuizCard.tsx
@@ -21,7 +21,14 @@ const QuizCard = ({ quiz, questionNumber }: QuizCardProps) => {
           {quiz.text}
         </p>
         <p className="text-body2-medium text-gray-600 max-md:text-tint-regular">
-          정답 : {quiz.answer}
+          정답 :{' '}
+          {quiz.type === 'TRUE_FALSE'
+            ? quiz.answer === 'TRUE'
+              ? 'O'
+              : quiz.answer === 'FALSE'
+                ? 'X'
+                : quiz.answer
+            : quiz.answer}
         </p>
       </div>
 


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: close #87  (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - 온보딩 데이터 중 대학생 -> 대학(원)생으로 수정
    - 문제 모아보기 OX 문제의 답안이 O X가 아닌 TRUE FASLE로 표기되는 것을 올바르게 수정
                          
- 테스트
    - <img width="1879" height="1362" alt="image" src="https://github.com/user-attachments/assets/9fab2856-fdfd-4dcc-808b-16483a163706" />
    - <img width="1615" height="1341" alt="image" src="https://github.com/user-attachments/assets/0ca1d2f7-5222-48e2-8c8f-129abd15a9bb" />
    - npm run build 확인

