### PR TITLE
feat: 마이페이지 FAQ 진입 동선 추가

### DIFF
--- a/src/app/pages/AnalyticsPage.tsx
+++ b/src/app/pages/AnalyticsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import {
   getUserInfo,
   updateNickname,
@@ -7,7 +7,7 @@ import {
   logout,
   type ReadUserInfoResponse,
 } from '@/api/account'
-import { Header, Footer, Button } from '@/components'
+import { Header, Footer, Button, MyPageTabs } from '@/components'
 import CumulativeSummary from '@/components/dashboard/cumulative-summary'
 import HourlyChart from '@/components/dashboard/hourly-chart'
 import LearningStats from '@/components/dashboard/learning-stats'
@@ -22,8 +22,10 @@ type TabType = 'analytics' | 'account'
 
 const AnalyticsPage = () => {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const { userInfo: contextUserInfo, refreshUserInfo } = useUser()
-  const [activeTab, setActiveTab] = useState<TabType>('analytics')
+  const activeTab: TabType =
+    searchParams.get('tab') === 'account' ? 'account' : 'analytics'
   const [userInfo, setUserInfo] = useState<ReadUserInfoResponse | null>(null)
   const [nickname, setNickname] = useState('')
   const [email, setEmail] = useState('')
@@ -214,29 +216,10 @@ const AnalyticsPage = () => {
       <main className="flex-1 flex flex-col items-center pt-20 pb-24 px-[60px] max-lg:px-10 max-md:px-5 max-md:pt-5">
         <div className="w-full max-w-[1024px] max-lg:max-w-full max-md:max-w-full">
           {/* 탭 헤더 */}
-          <div className="mb-[30px] max-md:mb-[31px]">
-            <div className="flex items-center gap-6 max-lg:gap-4 max-md:gap-4 mb-[6px] max-md:mb-5">
-              <button
-                onClick={() => setActiveTab('analytics')}
-                className={`text-[32px] max-lg:text-[28px] max-md:text-[24px] font-bold leading-[44.8px] max-lg:leading-[39.2px] max-md:leading-[33.6px] ${
-                  activeTab === 'analytics' ? 'text-gray-900' : 'text-gray-300'
-                }`}
-              >
-                학습분석
-              </button>
-              <button
-                onClick={() => setActiveTab('account')}
-                className={`text-[32px] max-lg:text-[28px] max-md:text-[24px] font-bold leading-[44.8px] max-lg:leading-[39.2px] max-md:leading-[33.6px] ${
-                  activeTab === 'account' ? 'text-gray-900' : 'text-gray-300'
-                }`}
-              >
-                계정관리
-              </button>
-            </div>
-            <p className="text-[20px] max-lg:text-[18px] max-md:text-[16px] leading-[28px] max-lg:leading-[25.2px] max-md:leading-[22.4px] text-gray-600">
-              학습 현황을 확인하고 계정을 관리하세요
-            </p>
-          </div>
+          <MyPageTabs
+            active={activeTab}
+            description="학습 현황을 확인하고 계정을 관리하세요"
+          />
 
           {activeTab === 'analytics' && (
             <div className="flex flex-col gap-5 max-md:gap-[20px]">

--- a/src/app/pages/FaqPage.tsx
+++ b/src/app/pages/FaqPage.tsx
@@ -1,11 +1,9 @@
-import { useNavigate } from 'react-router-dom'
-import { Header, Footer, FaqCategorySection } from '@/components'
+import { Header, Footer, FaqCategorySection, MyPageTabs } from '@/components'
 import { useFaqs } from '@/hooks/useFaqs'
 
 const CONTACT_EMAIL = 'duwn1010@gmail.com'
 
 const FaqPage = () => {
-  const navigate = useNavigate()
   const { data, isLoading, isError } = useFaqs()
   const groups = data?.faqCategoryGroupList ?? []
 
@@ -16,28 +14,10 @@ const FaqPage = () => {
       <main className="flex-1 flex flex-col items-center pt-20 pb-24 px-[60px] max-lg:px-10 max-md:px-5 max-md:pt-5">
         <div className="w-full max-w-[976px] max-lg:max-w-[904px] max-md:max-w-full">
           {/* 상단 탭 */}
-          <div className="mb-[30px]">
-            <div className="flex items-center gap-6 max-md:gap-4 mb-[6px]">
-              <button
-                onClick={() => navigate('/analytics')}
-                className="text-header1-bold max-lg:text-[32px] max-md:text-header3-bold text-gray-300"
-              >
-                학습분석
-              </button>
-              <span className="text-header1-bold max-lg:text-[32px] max-md:text-header3-bold text-gray-900">
-                FAQ
-              </span>
-              <button
-                onClick={() => navigate('/analytics')}
-                className="text-header1-bold max-lg:text-[32px] max-md:text-header3-bold text-gray-300"
-              >
-                계정관리
-              </button>
-            </div>
-            <p className="text-[20px] max-md:text-[16px] leading-[1.4] text-gray-600">
-              Quizly에 대해 궁금한 점을 빠르게 찾아보세요
-            </p>
-          </div>
+          <MyPageTabs
+            active="faq"
+            description="Quizly에 대해 궁금한 점을 빠르게 찾아보세요"
+          />
 
           {/* 본문: 로딩 / 에러 / 빈 / 데이터주도 렌더 */}
           {isLoading ? (

--- a/src/components/domain/MyPageTabs.tsx
+++ b/src/components/domain/MyPageTabs.tsx
@@ -1,0 +1,50 @@
+import { useNavigate } from 'react-router-dom'
+
+export type MyPageTab = 'analytics' | 'faq' | 'account'
+
+const TABS: { id: MyPageTab; label: string; to: string }[] = [
+  { id: 'analytics', label: '학습분석', to: '/analytics' },
+  { id: 'faq', label: 'FAQ', to: '/faq' },
+  { id: 'account', label: '계정관리', to: '/analytics?tab=account' },
+]
+
+interface MyPageTabsProps {
+  active: MyPageTab
+  description: string
+}
+
+const MyPageTabs = ({ active, description }: MyPageTabsProps) => {
+  const navigate = useNavigate()
+
+  return (
+    <div className="mb-[30px]">
+      <div className="flex items-center gap-6 max-md:gap-4 mb-[6px] max-md:mb-2">
+        {TABS.map((tab) =>
+          tab.id === active ? (
+            <span
+              key={tab.id}
+              aria-current="page"
+              className="text-header1-bold max-md:text-header3-bold text-gray-900"
+            >
+              {tab.label}
+            </span>
+          ) : (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => navigate(tab.to)}
+              className="text-header1-bold max-md:text-header3-bold text-gray-300"
+            >
+              {tab.label}
+            </button>
+          ),
+        )}
+      </div>
+      <p className="text-[20px] max-md:text-[16px] leading-[1.4] text-gray-600">
+        {description}
+      </p>
+    </div>
+  )
+}
+
+export default MyPageTabs

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -24,6 +24,8 @@ export { default as FaqAccordionItem } from './common/FaqAccordionItem'
 
 // Domain Components
 export { default as FaqCategorySection } from './domain/FaqCategorySection'
+export { default as MyPageTabs } from './domain/MyPageTabs'
+export type { MyPageTab } from './domain/MyPageTabs'
 
 // Modal Components
 export { default as MockExamSettingModal } from './modal/MockExamSettingModal'


### PR DESCRIPTION
- MyPageTabs 공용 컴포넌트 추가 (학습분석 · FAQ · 계정관리 3탭)
- AnalyticsPage 탭 상태를 URL 쿼리(?tab=account)로 전환
- FaqPage에서 계정관리 탭이 실제 계정관리로 이동하도록 연결